### PR TITLE
Adds Type definition for Limits

### DIFF
--- a/library/src/main/java/kwasm/ast/Limit.kt
+++ b/library/src/main/java/kwasm/ast/Limit.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kwasm.ast
+
+import kwasm.format.text.IntegerLiteral
+
+data class Limit(val min: IntegerLiteral.Unsigned, val max: IntegerLiteral.Unsigned)

--- a/library/src/main/java/kwasm/ast/Limit.kt
+++ b/library/src/main/java/kwasm/ast/Limit.kt
@@ -15,5 +15,9 @@
 package kwasm.ast
 
 import kwasm.format.text.IntegerLiteral
+import kwasm.format.text.Type.Limits
 
+/**
+ * This is a data class that represents the limits of a [Limits] object.
+ */
 data class Limit(val min: IntegerLiteral.Unsigned, val max: IntegerLiteral.Unsigned)

--- a/library/src/main/java/kwasm/format/text/Type.kt
+++ b/library/src/main/java/kwasm/format/text/Type.kt
@@ -43,14 +43,14 @@ sealed class Type<T>(
         sequence: CharSequence,
         context: ParseContext? = null
     ) : Type<kwasm.ast.ValueType>(sequence, context) {
-        override fun parseValue(): kwasm.ast.ValueType = when (sequence){
-                "i32" -> kwasm.ast.ValueType.I32
-                "i64" -> kwasm.ast.ValueType.I64
-                "f32" -> kwasm.ast.ValueType.F32
-                "f64" -> kwasm.ast.ValueType.F64
-                else -> throw ParseException("Invalid ValueType", context)
-            }
+        override fun parseValue(): kwasm.ast.ValueType = when (sequence) {
+            "i32" -> kwasm.ast.ValueType.I32
+            "i64" -> kwasm.ast.ValueType.I64
+            "f32" -> kwasm.ast.ValueType.F32
+            "f64" -> kwasm.ast.ValueType.F64
+            else -> throw ParseException("Invalid ValueType", context)
         }
+    }
 
     class ResultType(
         sequence: CharSequence,
@@ -59,7 +59,7 @@ sealed class Type<T>(
         override fun parseValue(): kwasm.ast.ValueType? {
             if (sequence.isEmpty()) return null
             val keywordAndParameters = getOperationAndParameters(sequence, context)
-            if(keywordAndParameters.first != "result" || keywordAndParameters.second.size > 1){
+            if (keywordAndParameters.first != "result" || keywordAndParameters.second.size > 1) {
                 throw ParseException("Invalid ResultType syntax", context.shiftColumnBy(1))
             }
             // Context is shifted by 8 to shift past '(result ' to the start of the actual ValueType

--- a/library/src/main/java/kwasm/format/text/Type.kt
+++ b/library/src/main/java/kwasm/format/text/Type.kt
@@ -112,14 +112,14 @@ sealed class Type<T>(
             // If sequence doesn't contain a space, that means we are only dealing with 1 number
             return if (" " !in sequence) {
                 if (sequence.isEmpty()) {
-                    throw ParseException("Invalid number of arguments. Expected 1 or 2 but found 0")
+                    throw ParseException("Invalid number of arguments. Expected 1 or 2 but found 0", context)
                 }
                 val min = IntegerLiteral.Unsigned(sequence, 32, context)
                 Limit(min, IntegerLiteral.Unsigned(UInt.MAX_VALUE.toString(), 32, null))
             } else {
                 val numbers = sequence.split(" ")
                 if (numbers.size != 2) {
-                    throw ParseException("Invalid number of arguments. Expected 1 or 2 but found ${numbers.size}")
+                    throw ParseException("Invalid number of arguments. Expected 1 or 2 but found ${numbers.size}", context)
                 }
                 val min = IntegerLiteral.Unsigned(numbers[0], 32, context)
                 val max = IntegerLiteral.Unsigned(

--- a/library/src/main/java/kwasm/format/text/Utils.kt
+++ b/library/src/main/java/kwasm/format/text/Utils.kt
@@ -123,29 +123,6 @@ fun CharSequence.parseStringChar(
     context: ParseContext? = null
 ): StringChar = codePoints().toArray().parseStringChar(index, inoutVal, context)
 
-@UseExperimental(ExperimentalUnsignedTypes::class)
-fun CharSequence.toUInt(context: ParseContext? = null): UInt {
-    if ("-" in this) {
-        throw ParseException("Negative values are not allowed in limits", context)
-    }
-    var powerVal = 1.toUInt()
-    var power = 0
-    val value = ByteArray(this.length)
-    repeat(this.length) { index -> value[index] = this.parseDigit(index, context) }
-    val convertedValue = value.foldRightIndexed(0.toUInt()) { _, charVal, acc ->
-        if (power > 0) {
-            powerVal *= 10u
-        }
-        power++
-        val byteVal = charVal.toInt()
-        acc + byteVal.toUInt() * powerVal
-    }
-    if (convertedValue.toString() != this) {
-        throw ParseException("Value overflow, specified value was larger than UInt.MAX_VALUE", context)
-    }
-    return convertedValue
-}
-
 fun IntArray.parseStringChar(
     index: Int,
     inoutVal: StringChar = StringChar(),
@@ -259,7 +236,7 @@ fun getOperationAndParameters(sequence: CharSequence, context: ParseContext?): P
     }
 
     val splitSequence = sequence.substring(1, sequence.lastIndex).split("\\s".toRegex())
-    return Pair(splitSequence[0], splitSequence.subList(1,splitSequence.lastIndex+1))
+    return Pair(splitSequence[0], splitSequence.subList(1, splitSequence.lastIndex + 1))
 }
 
 internal object NumberConstants {

--- a/library/src/test/java/kwasm/format/text/LimitsTest.kt
+++ b/library/src/test/java/kwasm/format/text/LimitsTest.kt
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kwasm.format.text
+
+import com.google.common.truth.Truth
+import kwasm.format.ParseException
+import org.assertj.core.api.Assertions
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+@UseExperimental(ExperimentalUnsignedTypes::class)
+class LimitsTest {
+
+    @Test
+    fun parseSingleNumber_setMinToCorrectValue() {
+        val expectedMin = 123456.toUInt()
+        val expectedMax = UInt.MAX_VALUE
+        val limits = Type.Limits("123456")
+        Truth.assertThat(limits.value.first).isEqualTo(expectedMin)
+        Truth.assertThat(limits.value.second).isEqualTo(expectedMax)
+    }
+
+    @Test
+    fun parseMaxVal_setMinToMaxVal() {
+        val expectedMin = UInt.MAX_VALUE
+        val expectedMax = UInt.MAX_VALUE
+        val limits = Type.Limits("4294967295")
+        Truth.assertThat(limits.value.first).isEqualTo(expectedMin)
+        Truth.assertThat(limits.value.second).isEqualTo(expectedMax)
+    }
+
+    @Test
+    fun parseMinVal_setMinToMaxVal() {
+        val expectedMin = UInt.MIN_VALUE
+        val expectedMax = UInt.MAX_VALUE
+        val limits = Type.Limits("0")
+        Truth.assertThat(limits.value.first).isEqualTo(expectedMin)
+        Truth.assertThat(limits.value.second).isEqualTo(expectedMax)
+    }
+
+    @Test
+    fun parseNegativeMin_throwsParseExceptionWithNegativeNumberMessage() {
+        val limits = Type.Limits("-123456")
+        Assertions.assertThatThrownBy { limits.value }
+            .isInstanceOf(ParseException::class.java)
+            .hasMessageContaining("Negative values are not allowed in limits")
+    }
+
+    @Test
+    fun parseABitLargerThanMaxVal_throwsParseExceptionWithValueOverflowMessage() {
+        val limits = Type.Limits("4294967296")
+        Assertions.assertThatThrownBy { limits.value }
+            .isInstanceOf(ParseException::class.java)
+            .hasMessageContaining("Value overflow, specified value was larger than UInt.MAX_VALUE")
+    }
+
+    @Test
+    fun parseALotLargerThanMaxVal_throwsParseExceptionWithValueOverflowMessage() {
+        val limits = Type.Limits("100000000000")
+        Assertions.assertThatThrownBy { limits.value }
+            .isInstanceOf(ParseException::class.java)
+            .hasMessageContaining("Value overflow, specified value was larger than UInt.MAX_VALUE")
+    }
+
+    @Test
+    fun parseTwoNumbers_setMinAndMaxToCorrectValue() {
+        val expectedMin = 123456.toUInt()
+        val expectedMax = 234567.toUInt()
+        val limits = Type.Limits("123456 234567")
+        Truth.assertThat(limits.value.first).isEqualTo(expectedMin)
+        Truth.assertThat(limits.value.second).isEqualTo(expectedMax)
+    }
+
+    @Test
+    fun parseTwoNumbers_withMinGreaterThanMax_throwsParseExceptionWithInvalidRangeMessage() {
+        val limits = Type.Limits("234567 123456")
+        Assertions.assertThatThrownBy { limits.value }
+            .isInstanceOf(ParseException::class.java)
+            .hasMessageContaining("Invalid Range specified, min > max.")
+    }
+
+    @Test
+    fun parseTwoValuesWithNegativeMin_throwsParseExceptionWithNegativeNumberMessage() {
+        val limits = Type.Limits("-123456 234567")
+        Assertions.assertThatThrownBy { limits.value }
+            .isInstanceOf(ParseException::class.java)
+            .hasMessageContaining("Negative values are not allowed in limits")
+    }
+
+    @Test
+    fun parseTwoValuesWithMinABitLargerThanMaxVal_throwsParseExceptionWithValueOverflowMessage() {
+        val limits = Type.Limits("4294967296 234567")
+        Assertions.assertThatThrownBy { limits.value }
+            .isInstanceOf(ParseException::class.java)
+            .hasMessageContaining("Value overflow, specified value was larger than UInt.MAX_VALUE")
+    }
+
+    @Test
+    fun parseTwoValuesWithMinALotLargerThanMaxVal_throwsParseExceptionWithValueOverflowMessage() {
+        val limits = Type.Limits("100000000000 234567")
+        Assertions.assertThatThrownBy { limits.value }
+            .isInstanceOf(ParseException::class.java)
+            .hasMessageContaining("Value overflow, specified value was larger than UInt.MAX_VALUE")
+    }
+
+    @Test
+    fun parseTwoValuesWithNegativeMax_throwsParseExceptionWithNegativeNumberMessage() {
+        val limits = Type.Limits("123456 -234567")
+        Assertions.assertThatThrownBy { limits.value }
+            .isInstanceOf(ParseException::class.java)
+            .hasMessageContaining("Negative values are not allowed in limits")
+    }
+
+    @Test
+    fun parseTwoValuesWithMaxABitLargerThanMaxVal_throwsParseExceptionWithValueOverflowMessage() {
+        val limits = Type.Limits("1234567 4294967296")
+        Assertions.assertThatThrownBy { limits.value }
+            .isInstanceOf(ParseException::class.java)
+            .hasMessageContaining("Value overflow, specified value was larger than UInt.MAX_VALUE")
+    }
+
+    @Test
+    fun parseTwoValuesWithMaxALotLargerThanMaxVal_throwsParseExceptionWithValueOverflowMessage() {
+        val limits = Type.Limits("1234567 100000000000")
+        Assertions.assertThatThrownBy { limits.value }
+            .isInstanceOf(ParseException::class.java)
+            .hasMessageContaining("Value overflow, specified value was larger than UInt.MAX_VALUE")
+    }
+
+    @Test
+    fun parseNoValues_throwsParseExceptionWithIncorrectNumberOfArgumentsException() {
+        val limits = Type.Limits("")
+        Assertions.assertThatThrownBy { limits.value }
+            .isInstanceOf(ParseException::class.java)
+            .hasMessageContaining("Invalid number of arguments.")
+    }
+
+    @Test
+    fun parseThreeValues_throwsParseExceptionWithIncorrectNumberOfArgumentsException() {
+        val limits = Type.Limits("1234567 2345678 3456789")
+        Assertions.assertThatThrownBy { limits.value }
+            .isInstanceOf(ParseException::class.java)
+            .hasMessageContaining("Invalid number of arguments.")
+    }
+}

--- a/library/src/test/java/kwasm/format/text/LimitsTest.kt
+++ b/library/src/test/java/kwasm/format/text/LimitsTest.kt
@@ -27,62 +27,62 @@ class LimitsTest {
 
     @Test
     fun parseSingleNumber_setMinToCorrectValue() {
-        val expectedMin = 123456.toUInt()
-        val expectedMax = UInt.MAX_VALUE
+        val expectedMin = 123456.toULong()
+        val expectedMax = UInt.MAX_VALUE.toULong()
         val limits = Type.Limits("123456")
-        Truth.assertThat(limits.value.first).isEqualTo(expectedMin)
-        Truth.assertThat(limits.value.second).isEqualTo(expectedMax)
+        Truth.assertThat(limits.value.min.value).isEqualTo(expectedMin)
+        Truth.assertThat(limits.value.max.value).isEqualTo(expectedMax)
     }
 
     @Test
     fun parseMaxVal_setMinToMaxVal() {
-        val expectedMin = UInt.MAX_VALUE
-        val expectedMax = UInt.MAX_VALUE
-        val limits = Type.Limits("4294967295")
-        Truth.assertThat(limits.value.first).isEqualTo(expectedMin)
-        Truth.assertThat(limits.value.second).isEqualTo(expectedMax)
+        val expectedMin = UInt.MAX_VALUE.toULong()
+        val expectedMax = UInt.MAX_VALUE.toULong()
+        val limits = Type.Limits(UInt.MAX_VALUE.toString())
+        Truth.assertThat(limits.value.min.value).isEqualTo(expectedMin)
+        Truth.assertThat(limits.value.max.value).isEqualTo(expectedMax)
     }
 
     @Test
-    fun parseMinVal_setMinToMaxVal() {
-        val expectedMin = UInt.MIN_VALUE
-        val expectedMax = UInt.MAX_VALUE
-        val limits = Type.Limits("0")
-        Truth.assertThat(limits.value.first).isEqualTo(expectedMin)
-        Truth.assertThat(limits.value.second).isEqualTo(expectedMax)
+    fun parseMinVal_setMinToMinVal() {
+        val expectedMin = UInt.MIN_VALUE.toULong()
+        val expectedMax = UInt.MAX_VALUE.toULong()
+        val limits = Type.Limits(UInt.MIN_VALUE.toString())
+        Truth.assertThat(limits.value.min.value).isEqualTo(expectedMin)
+        Truth.assertThat(limits.value.max.value).isEqualTo(expectedMax)
     }
 
     @Test
     fun parseNegativeMin_throwsParseExceptionWithNegativeNumberMessage() {
         val limits = Type.Limits("-123456")
-        Assertions.assertThatThrownBy { limits.value }
+        Assertions.assertThatThrownBy { limits.value.min.value }
             .isInstanceOf(ParseException::class.java)
-            .hasMessageContaining("Negative values are not allowed in limits")
+            .hasMessageContaining("Illegal char")
     }
 
     @Test
     fun parseABitLargerThanMaxVal_throwsParseExceptionWithValueOverflowMessage() {
         val limits = Type.Limits("4294967296")
-        Assertions.assertThatThrownBy { limits.value }
+        Assertions.assertThatThrownBy { limits.value.min.value }
             .isInstanceOf(ParseException::class.java)
-            .hasMessageContaining("Value overflow, specified value was larger than UInt.MAX_VALUE")
+            .hasMessageContaining("Illegal value")
     }
 
     @Test
     fun parseALotLargerThanMaxVal_throwsParseExceptionWithValueOverflowMessage() {
         val limits = Type.Limits("100000000000")
-        Assertions.assertThatThrownBy { limits.value }
+        Assertions.assertThatThrownBy { limits.value.min.value }
             .isInstanceOf(ParseException::class.java)
-            .hasMessageContaining("Value overflow, specified value was larger than UInt.MAX_VALUE")
+            .hasMessageContaining("Illegal value")
     }
 
     @Test
     fun parseTwoNumbers_setMinAndMaxToCorrectValue() {
-        val expectedMin = 123456.toUInt()
-        val expectedMax = 234567.toUInt()
+        val expectedMin = 123456.toUInt().toULong()
+        val expectedMax = 234567.toUInt().toULong()
         val limits = Type.Limits("123456 234567")
-        Truth.assertThat(limits.value.first).isEqualTo(expectedMin)
-        Truth.assertThat(limits.value.second).isEqualTo(expectedMax)
+        Truth.assertThat(limits.value.min.value).isEqualTo(expectedMin)
+        Truth.assertThat(limits.value.max.value).isEqualTo(expectedMax)
     }
 
     @Test
@@ -98,7 +98,7 @@ class LimitsTest {
         val limits = Type.Limits("-123456 234567")
         Assertions.assertThatThrownBy { limits.value }
             .isInstanceOf(ParseException::class.java)
-            .hasMessageContaining("Negative values are not allowed in limits")
+            .hasMessageContaining("Illegal char")
     }
 
     @Test
@@ -106,7 +106,7 @@ class LimitsTest {
         val limits = Type.Limits("4294967296 234567")
         Assertions.assertThatThrownBy { limits.value }
             .isInstanceOf(ParseException::class.java)
-            .hasMessageContaining("Value overflow, specified value was larger than UInt.MAX_VALUE")
+            .hasMessageContaining("Illegal value")
     }
 
     @Test
@@ -114,7 +114,7 @@ class LimitsTest {
         val limits = Type.Limits("100000000000 234567")
         Assertions.assertThatThrownBy { limits.value }
             .isInstanceOf(ParseException::class.java)
-            .hasMessageContaining("Value overflow, specified value was larger than UInt.MAX_VALUE")
+            .hasMessageContaining("Illegal value")
     }
 
     @Test
@@ -122,7 +122,7 @@ class LimitsTest {
         val limits = Type.Limits("123456 -234567")
         Assertions.assertThatThrownBy { limits.value }
             .isInstanceOf(ParseException::class.java)
-            .hasMessageContaining("Negative values are not allowed in limits")
+            .hasMessageContaining("Illegal char")
     }
 
     @Test
@@ -130,7 +130,7 @@ class LimitsTest {
         val limits = Type.Limits("1234567 4294967296")
         Assertions.assertThatThrownBy { limits.value }
             .isInstanceOf(ParseException::class.java)
-            .hasMessageContaining("Value overflow, specified value was larger than UInt.MAX_VALUE")
+            .hasMessageContaining("Illegal value")
     }
 
     @Test
@@ -138,7 +138,7 @@ class LimitsTest {
         val limits = Type.Limits("1234567 100000000000")
         Assertions.assertThatThrownBy { limits.value }
             .isInstanceOf(ParseException::class.java)
-            .hasMessageContaining("Value overflow, specified value was larger than UInt.MAX_VALUE")
+            .hasMessageContaining("Illegal value")
     }
 
     @Test


### PR DESCRIPTION
Resolves #12 

So, I think I moved the context correctly, please verify. Also am I missing test cases? Here is what I have:

For 1 value:
Value set to UInt.MIN_VALUE parses correctly
Value set to UInt.MAX_VALUE parses correctly
Value set to a random value parses correctly
Value set to a negative value throws a Parse Exception
Value set to a value large than UInt.Max_VALUE throws a parse exception

For 2 Values:
Values set to random values parses correctly
Values set so that min > max throws parse exception
Value 1 set to a negative value throws a Parse Exception
Value 1 set to a value large than UInt.Max_VALUE throws a parse exception
Value 2 set to a negative value throws a Parse Exception
Value 2 set to a value large than UInt.Max_VALUE throws a parse exception