### PR TITLE
Generate an identifier when none is found during parsing.

### DIFF
--- a/library/src/main/java/kwasm/ast/Identifier.kt
+++ b/library/src/main/java/kwasm/ast/Identifier.kt
@@ -39,40 +39,56 @@ sealed class Identifier(
     data class Type(
         override val stringRepr: String? = null,
         override val unique: Int? = "$stringRepr".hashCode()
-    ) : Identifier(unique, stringRepr)
+    ) : Identifier(unique, stringRepr) {
+        override fun toString() = "$stringRepr"
+    }
 
     data class Function(
         override val stringRepr: String? = null,
         override val unique: Int? = "$stringRepr".hashCode()
-    ) : Identifier(unique, stringRepr)
+    ) : Identifier(unique, stringRepr) {
+        override fun toString() = "$stringRepr"
+    }
 
     data class Table(
         override val stringRepr: String? = null,
         override val unique: Int? = "$stringRepr".hashCode()
-    ) : Identifier(unique, stringRepr)
+    ) : Identifier(unique, stringRepr) {
+        override fun toString() = "$stringRepr"
+    }
 
     data class Memory(
         override val stringRepr: String? = null,
         override val unique: Int? = "$stringRepr".hashCode()
-    ) : Identifier(unique, stringRepr)
+    ) : Identifier(unique, stringRepr) {
+        override fun toString() = "$stringRepr"
+    }
 
     data class Global(
         override val stringRepr: String? = null,
         override val unique: Int? = "$stringRepr".hashCode()
-    ) : Identifier(unique, stringRepr)
+    ) : Identifier(unique, stringRepr) {
+        override fun toString() = "$stringRepr"
+    }
 
     data class Local(
         override val stringRepr: String? = null,
         override val unique: Int? = "$stringRepr".hashCode()
-    ) : Identifier(unique, stringRepr)
+    ) : Identifier(unique, stringRepr) {
+        override fun toString() = "$stringRepr"
+    }
 
     data class Label(
         override val stringRepr: String? = null,
         override val unique: Int? = "$stringRepr".hashCode()
-    ) : Identifier(unique, stringRepr)
+    ) : Identifier(unique, stringRepr) {
+        override fun toString() = "$stringRepr"
+    }
 
     data class TypeDef(
         val funcType: FunctionType,
         override val stringRepr: String? = null
-    ) : Identifier(null, stringRepr)
+    ) : Identifier(null, stringRepr) {
+        override fun toString() = "$stringRepr"
+    }
 }

--- a/library/src/main/java/kwasm/format/text/Identifier.kt
+++ b/library/src/main/java/kwasm/format/text/Identifier.kt
@@ -44,7 +44,7 @@ inline fun <reified T : Identifier> List<Token>.parseIdentifier(fromIndex: Int, 
                 ?.takeIf { it.unique != null && (it.unique as Int) >= 0 },
             "Identifier must not be negative"
         )
-    } else createIdentifier<T>(null, null)
+    } else createIdentifier<T>("\$token-${getOrNull(fromIndex).hashCode()}")
     return id?.let { ParseResult(it, currentIndex - fromIndex) }
         ?: throw ParseException("Unsupported identifier type: ${T::class}", contextAt(fromIndex))
 }

--- a/library/src/main/java/kwasm/format/text/module/Global.kt
+++ b/library/src/main/java/kwasm/format/text/module/Global.kt
@@ -189,8 +189,12 @@ fun List<Token>.parseInlineGlobalExport(fromIndex: Int): ParseResult<AstNodeList
     )
 
     // Add the id.
-    (0 until identifier.parseLength).forEach {
-        withoutFirstExport.add(this[fromIndex + 2 + it])
+    if (identifier.parseLength == 0) {
+        withoutFirstExport.add(kwasm.format.text.token.Identifier(identifier.astNode.toString()))
+    } else {
+        (0 until identifier.parseLength).forEach {
+            withoutFirstExport.add(this[fromIndex + 2 + it])
+        }
     }
 
     val lengthOfPrefix = withoutFirstExport.size

--- a/library/src/main/java/kwasm/format/text/module/Memory.kt
+++ b/library/src/main/java/kwasm/format/text/module/Memory.kt
@@ -275,8 +275,12 @@ fun List<Token>.parseInlineMemoryExport(fromIndex: Int): ParseResult<AstNodeList
     )
 
     // Add the id.
-    (0 until identifier.parseLength).forEach {
-        withoutFirstExport.add(this[fromIndex + 2 + it])
+    if (identifier.parseLength == 0) {
+        withoutFirstExport.add(kwasm.format.text.token.Identifier(identifier.astNode.toString()))
+    } else {
+        (0 until identifier.parseLength).forEach {
+            withoutFirstExport.add(this[fromIndex + 2 + it])
+        }
     }
 
     val lengthOfPrefix = withoutFirstExport.size

--- a/library/src/main/java/kwasm/format/text/module/Table.kt
+++ b/library/src/main/java/kwasm/format/text/module/Table.kt
@@ -272,8 +272,12 @@ fun List<Token>.parseInlineTableExport(fromIndex: Int): ParseResult<AstNodeList<
     )
 
     // Add the id.
-    (0 until identifier.parseLength).forEach {
-        withoutFirstExport.add(this[fromIndex + 2 + it])
+    if (identifier.parseLength == 0) {
+        withoutFirstExport.add(kwasm.format.text.token.Identifier(identifier.astNode.toString()))
+    } else {
+        (0 until identifier.parseLength).forEach {
+            withoutFirstExport.add(this[fromIndex + 2 + it])
+        }
     }
 
     val lengthOfPrefix = withoutFirstExport.size

--- a/library/src/main/java/kwasm/format/text/module/WasmFunction.kt
+++ b/library/src/main/java/kwasm/format/text/module/WasmFunction.kt
@@ -174,8 +174,12 @@ fun List<Token>.parseInlineWasmFunctionExport(fromIndex: Int): ParseResult<AstNo
     )
 
     // Add the id.
-    (0 until id.parseLength).forEach {
-        withoutFirstExport.add(this[fromIndex + 2 + it])
+    if (id.parseLength == 0) {
+        withoutFirstExport.add(kwasm.format.text.token.Identifier(id.astNode.toString()))
+    } else {
+        (0 until id.parseLength).forEach {
+            withoutFirstExport.add(this[fromIndex + 2 + it])
+        }
     }
 
     val lengthOfPrefix = withoutFirstExport.size

--- a/library/src/main/java/kwasm/format/text/token/Identifier.kt
+++ b/library/src/main/java/kwasm/format/text/token/Identifier.kt
@@ -14,7 +14,7 @@
 
 package kwasm.format.text.token
 
-import kwasm.ast.Identifier
+import kwasm.ast.Identifier as AstIdentifier
 import kwasm.format.ParseContext
 import kwasm.format.ParseException
 import kwasm.format.text.token.util.TokenMatchResult
@@ -35,7 +35,8 @@ import kwasm.format.text.token.util.TokenMatchResult
  *              ':', '<', '=', '>', '?', '@', '\', '^', '_', '`', '|', '~'
  * ```
  */
-data class Identifier(
+@Suppress("EqualsOrHashCode")
+class Identifier(
     private val sequence: CharSequence,
     override val context: ParseContext? = null
 ) : Token {
@@ -49,16 +50,22 @@ data class Identifier(
         "$sequence"
     }
 
+    override fun equals(other: Any?): Boolean {
+        if (other === this) return true
+        if (other !is kwasm.format.text.token.Identifier) return false
+        return other.sequence == sequence
+    }
+
     /** Gets an instance of a [kwasm.ast.Identifier] based on the [value]. */
-    inline fun <reified IdentifierType : Identifier> getAstValue(): IdentifierType =
+    inline fun <reified IdentifierType : AstIdentifier> getAstValue(): IdentifierType =
         when (IdentifierType::class) {
-            Identifier.Type::class -> Identifier.Type(stringRepr = value)
-            Identifier.Function::class -> Identifier.Function(stringRepr = value)
-            Identifier.Global::class -> Identifier.Global(stringRepr = value)
-            Identifier.Label::class -> Identifier.Label(stringRepr = value)
-            Identifier.Local::class -> Identifier.Local(stringRepr = value)
-            Identifier.Memory::class -> Identifier.Memory(stringRepr = value)
-            Identifier.Table::class -> Identifier.Table(stringRepr = value)
+            AstIdentifier.Type::class -> AstIdentifier.Type(stringRepr = value)
+            AstIdentifier.Function::class -> AstIdentifier.Function(stringRepr = value)
+            AstIdentifier.Global::class -> AstIdentifier.Global(stringRepr = value)
+            AstIdentifier.Label::class -> AstIdentifier.Label(stringRepr = value)
+            AstIdentifier.Local::class -> AstIdentifier.Local(stringRepr = value)
+            AstIdentifier.Memory::class -> AstIdentifier.Memory(stringRepr = value)
+            AstIdentifier.Table::class -> AstIdentifier.Table(stringRepr = value)
             else -> throw ParseException(
                 "Unsupported AST Identifier type: ${IdentifierType::class.java}",
                 context
@@ -75,12 +82,12 @@ data class Identifier(
 }
 
 fun RawToken.findIdentifier(): TokenMatchResult? {
-    val match = kwasm.format.text.token.Identifier.PATTERN.get()
+    val match = Identifier.PATTERN.get()
         .findAll(sequence).maxBy { it.value.length } ?: return null
     return TokenMatchResult(match.range.first, match.value)
 }
 
 fun RawToken.isIdentifier(): Boolean =
-    kwasm.format.text.token.Identifier.PATTERN.get().matchEntire(sequence) != null
+    Identifier.PATTERN.get().matchEntire(sequence) != null
 
-fun RawToken.toIdentifier(): kwasm.format.text.token.Identifier = Identifier(sequence, context)
+fun RawToken.toIdentifier(): Identifier = Identifier(sequence, context)

--- a/library/src/main/java/kwasm/format/text/token/Paren.kt
+++ b/library/src/main/java/kwasm/format/text/token/Paren.kt
@@ -20,9 +20,16 @@ import kwasm.format.text.token.util.TokenMatchResult
 /** Representations of Open/Close Parentheses in source WebAssembly. */
 sealed class Paren : Token {
     /** Representation of `(`, and its location within the source. */
-    data class Open(override val context: ParseContext? = null) : Paren()
+    @Suppress("EqualsOrHashCode") // This is intentional.
+    class Open(override val context: ParseContext? = null) : Paren() {
+        override fun equals(other: Any?): Boolean = other is Open
+    }
+
     /** Representation of `)`, and its location within the source. */
-    data class Closed(override val context: ParseContext? = null) : Paren()
+    @Suppress("EqualsOrHashCode") // This is intentional.
+    class Closed(override val context: ParseContext? = null) : Paren() {
+        override fun equals(other: Any?): Boolean = other is Closed
+    }
 }
 
 fun RawToken.findParen(): TokenMatchResult? {

--- a/library/src/main/java/kwasm/validation/ValidationContext.kt
+++ b/library/src/main/java/kwasm/validation/ValidationContext.kt
@@ -200,21 +200,13 @@ fun ValidationContext(module: WasmModule): ValidationContext.Module {
                 upcastThrown { functions[descriptor.id] = typeUse }
             }
             is ImportDescriptor.Table -> {
-                validate(
-                    descriptor.id.stringRepr != null ||
-                        descriptor.id.unique != null ||
-                        tables[0] == null
-                ) {
+                validate(tables[0] == null) {
                     "Cannot import a table when one is already defined by the module"
                 }
                 upcastThrown { tables[descriptor.id] = descriptor.tableType }
             }
             is ImportDescriptor.Memory -> {
-                validate(
-                    descriptor.id.stringRepr != null ||
-                        descriptor.id.unique != null ||
-                        memories[0] == null
-                ) {
+                validate(memories[0] == null) {
                     "Cannot import a memory when one is already defined by the module"
                 }
                 upcastThrown { memories[descriptor.id] = descriptor.memoryType }

--- a/library/src/test/java/kwasm/format/text/module/GlobalInlineExportTest.kt
+++ b/library/src/test/java/kwasm/format/text/module/GlobalInlineExportTest.kt
@@ -93,14 +93,9 @@ class GlobalInlineExportTest {
             .parseInlineGlobalExport(0)
             ?: Assertions.fail("Expected a result")
         assertThat(result.parseLength).isEqualTo(7)
-        assertThat(result.astNode).containsExactly(
-            Export(
-                "a",
-                ExportDescriptor.Global(
-                    Index.ByIdentifier(Identifier.Global(null, null))
-                )
-            )
-        ).inOrder()
+        assertThat(result.astNode.size).isEqualTo(1)
+        val node = result.astNode[0] as Export
+        assertThat(node.name).isEqualTo("a")
     }
 
     @Test

--- a/library/src/test/java/kwasm/format/text/module/GlobalInlineImportTest.kt
+++ b/library/src/test/java/kwasm/format/text/module/GlobalInlineImportTest.kt
@@ -16,6 +16,7 @@ package kwasm.format.text.module
 
 import com.google.common.truth.Truth.assertThat
 import kwasm.ast.Identifier
+import kwasm.ast.module.Export
 import kwasm.ast.module.Import
 import kwasm.ast.module.ImportDescriptor
 import kwasm.ast.type.GlobalType
@@ -103,19 +104,11 @@ class GlobalInlineImportTest {
             ?: Assertions.fail("Expected a result")
 
         assertThat(result.parseLength).isEqualTo(9)
-        assertThat(result.astNode).isEqualTo(
-            Import(
-                "a",
-                "b",
-                ImportDescriptor.Global(
-                    Identifier.Global(null, null),
-                    GlobalType(
-                        ValueType.I32,
-                        false
-                    )
-                )
-            )
-        )
+        assertThat(result.astNode.moduleName).isEqualTo("a")
+        assertThat(result.astNode.name).isEqualTo("b")
+        val descriptor = result.astNode.descriptor as ImportDescriptor.Global
+        assertThat(descriptor.globalType.valueType).isEqualTo(ValueType.I32)
+        assertThat(descriptor.globalType.mutable).isFalse()
     }
 
     @Test

--- a/library/src/test/java/kwasm/format/text/module/GlobalInlineImportTest.kt
+++ b/library/src/test/java/kwasm/format/text/module/GlobalInlineImportTest.kt
@@ -16,7 +16,6 @@ package kwasm.format.text.module
 
 import com.google.common.truth.Truth.assertThat
 import kwasm.ast.Identifier
-import kwasm.ast.module.Export
 import kwasm.ast.module.Import
 import kwasm.ast.module.ImportDescriptor
 import kwasm.ast.type.GlobalType

--- a/library/src/test/java/kwasm/format/text/module/GlobalTest.kt
+++ b/library/src/test/java/kwasm/format/text/module/GlobalTest.kt
@@ -74,12 +74,11 @@ class GlobalTest {
         val result = tokenizer.tokenize("(global i32)", context).parseGlobal(0)
             ?: fail("Expected a result")
         assertThat(result.parseLength).isEqualTo(4)
-        assertThat(result.astNode).isEqualTo(
-            Global(
-                Identifier.Global(null, null),
-                GlobalType(ValueType.I32, false),
-                Expression(astNodeListOf())
-            )
+        assertThat(result.astNode.globalType).isEqualTo(
+            GlobalType(ValueType.I32, false)
+        )
+        assertThat(result.astNode.initExpression).isEqualTo(
+            Expression(astNodeListOf())
         )
     }
 
@@ -88,12 +87,11 @@ class GlobalTest {
         val result = tokenizer.tokenize("(global (mut i32))", context).parseGlobal(0)
             ?: fail("Expected a result")
         assertThat(result.parseLength).isEqualTo(7)
-        assertThat(result.astNode).isEqualTo(
-            Global(
-                Identifier.Global(null, null),
-                GlobalType(ValueType.I32, true),
-                Expression(astNodeListOf())
-            )
+        assertThat(result.astNode.globalType).isEqualTo(
+            GlobalType(ValueType.I32, true)
+        )
+        assertThat(result.astNode.initExpression).isEqualTo(
+            Expression(astNodeListOf())
         )
     }
 

--- a/library/src/test/java/kwasm/format/text/module/MemoryInlineExportTest.kt
+++ b/library/src/test/java/kwasm/format/text/module/MemoryInlineExportTest.kt
@@ -96,14 +96,10 @@ class MemoryInlineExportTest {
             .parseInlineMemoryExport(0)
             ?: Assertions.fail("Expected a result")
         assertThat(result.parseLength).isEqualTo(7)
-        assertThat(result.astNode).containsExactly(
-            Export(
-                "a",
-                ExportDescriptor.Memory(
-                    Index.ByIdentifier(Identifier.Memory(null, null))
-                )
-            )
-        ).inOrder()
+        assertThat(result.astNode.size).isEqualTo(1)
+        val export = result.astNode[0] as Export
+        assertThat(export.name).isEqualTo("a")
+        assertThat(export.descriptor).isInstanceOf(ExportDescriptor.Memory::class.java)
     }
 
     @Test

--- a/library/src/test/java/kwasm/format/text/module/MemoryInlineImportTest.kt
+++ b/library/src/test/java/kwasm/format/text/module/MemoryInlineImportTest.kt
@@ -104,18 +104,10 @@ class MemoryInlineImportTest {
             ?: Assertions.fail("Expected a result")
 
         assertThat(result.parseLength).isEqualTo(9)
-        assertThat(result.astNode).isEqualTo(
-            Import(
-                "a",
-                "b",
-                ImportDescriptor.Memory(
-                    Identifier.Memory(null, null),
-                    MemoryType(
-                        Limits(1)
-                    )
-                )
-            )
-        )
+        assertThat(result.astNode.moduleName).isEqualTo("a")
+        assertThat(result.astNode.name).isEqualTo("b")
+        val descriptor = result.astNode.descriptor as ImportDescriptor.Memory
+        assertThat(descriptor.memoryType).isEqualTo(MemoryType(Limits(1)))
     }
 
     @Test

--- a/library/src/test/java/kwasm/format/text/module/MemoryTest.kt
+++ b/library/src/test/java/kwasm/format/text/module/MemoryTest.kt
@@ -138,23 +138,18 @@ class MemoryTest {
         val result = tokenizer.tokenize("(memory (data))", context)
             .parseMemoryAndDataSegment(0) ?: Assertions.fail("Expected a result")
         assertThat(result.parseLength).isEqualTo(6)
-        assertThat(result.astNode).containsExactly(
-            Memory(
-                Identifier.Memory(null, null),
-                MemoryType(
-                    Limits(0, 0)
+        assertThat(result.astNode.size).isEqualTo(2)
+        val memory = result.astNode[0] as Memory
+        val dataSegment = result.astNode[1] as DataSegment
+        assertThat(memory.memoryType).isEqualTo(MemoryType(Limits(0, 0)))
+        assertThat(dataSegment.offset).isEqualTo(
+            Offset(
+                Expression(
+                    astNodeListOf(NumericConstantInstruction.I32(IntegerLiteral.S32(0)))
                 )
-            ),
-            DataSegment(
-                Index.ByIdentifier(Identifier.Memory(null, null)),
-                Offset(
-                    Expression(
-                        astNodeListOf(NumericConstantInstruction.I32(IntegerLiteral.S32(0)))
-                    )
-                ),
-                "".toByteArray(Charsets.UTF_8)
             )
-        ).inOrder()
+        )
+        assertThat(dataSegment.init).isEqualTo("".toByteArray(Charsets.UTF_8))
     }
 
     @Test

--- a/library/src/test/java/kwasm/format/text/module/TableInlineExportTest.kt
+++ b/library/src/test/java/kwasm/format/text/module/TableInlineExportTest.kt
@@ -97,14 +97,9 @@ class TableInlineExportTest {
             .parseInlineTableExport(0)
             ?: Assertions.fail("Expected a result")
         assertThat(result.parseLength).isEqualTo(7)
-        assertThat(result.astNode).containsExactly(
-            Export(
-                "a",
-                ExportDescriptor.Table(
-                    Index.ByIdentifier(Identifier.Table(null, null))
-                )
-            )
-        ).inOrder()
+        val export = result.astNode[0] as Export
+        assertThat(export.descriptor as? ExportDescriptor.Table).isNotNull()
+        assertThat(export.name).isEqualTo("a")
     }
 
     @Test

--- a/library/src/test/java/kwasm/format/text/module/TableInlineImportTest.kt
+++ b/library/src/test/java/kwasm/format/text/module/TableInlineImportTest.kt
@@ -105,17 +105,13 @@ class TableInlineImportTest {
             ?: Assertions.fail("Expected a result")
 
         assertThat(result.parseLength).isEqualTo(10)
-        assertThat(result.astNode).isEqualTo(
-            Import(
-                "a",
-                "b",
-                ImportDescriptor.Table(
-                    Identifier.Table(null, null),
-                    TableType(
-                        Limits(1),
-                        ElementType.FunctionReference
-                    )
-                )
+        assertThat(result.astNode.moduleName).isEqualTo("a")
+        assertThat(result.astNode.name).isEqualTo("b")
+        val descriptor = result.astNode.descriptor as ImportDescriptor.Table
+        assertThat(descriptor.tableType).isEqualTo(
+            TableType(
+                Limits(1),
+                ElementType.FunctionReference
             )
         )
     }

--- a/library/src/test/java/kwasm/format/text/module/TableTest.kt
+++ b/library/src/test/java/kwasm/format/text/module/TableTest.kt
@@ -154,24 +154,23 @@ class TableTest {
         val result = tokenizer.tokenize("(table funcref (elem))", context)
             .parseTableAndElementSegment(0) ?: fail("Expected a result")
         assertThat(result.parseLength).isEqualTo(7)
-        assertThat(result.astNode).containsExactly(
-            Table(
-                Identifier.Table(null, null),
-                TableType(
-                    Limits(0, 0),
-                    ElementType.FunctionReference
-                )
-            ),
-            ElementSegment(
-                Index.ByIdentifier(Identifier.Table(null, null)),
-                Offset(
-                    Expression(
-                        astNodeListOf(NumericConstantInstruction.I32(IntegerLiteral.S32(0)))
-                    )
-                ),
-                astNodeListOf()
+        val table = result.astNode[0] as Table
+        assertThat(table.tableType).isEqualTo(
+            TableType(
+                Limits(0, 0),
+                ElementType.FunctionReference
             )
-        ).inOrder()
+        )
+        val elementSegment = result.astNode[1] as ElementSegment
+        assertThat(elementSegment.tableIndex).isEqualTo(Index.ByIdentifier(table.id))
+        assertThat(elementSegment.offset).isEqualTo(
+            Offset(
+                Expression(
+                    astNodeListOf(NumericConstantInstruction.I32(IntegerLiteral.S32(0)))
+                )
+            )
+        )
+        assertThat(elementSegment.init).isEmpty()
     }
 
     @Test

--- a/library/src/test/java/kwasm/format/text/module/WasmFunctionInlineExportTest.kt
+++ b/library/src/test/java/kwasm/format/text/module/WasmFunctionInlineExportTest.kt
@@ -93,24 +93,21 @@ class WasmFunctionInlineExportTest {
             .parseInlineWasmFunctionExport(0)
             ?: fail("Expected a result")
         assertThat(result.parseLength).isEqualTo(7)
-        assertThat(result.astNode).containsExactly(
-            WasmFunction(
-                Identifier.Function(null, null),
-                TypeUse(
-                    null,
-                    astNodeListOf(),
-                    astNodeListOf()
-                ),
+        val func = result.astNode[0] as WasmFunction
+        val export = result.astNode[1] as Export
+
+        assertThat(func.typeUse).isEqualTo(
+            TypeUse(
+                null,
                 astNodeListOf(),
                 astNodeListOf()
-            ),
-            Export(
-                "a",
-                ExportDescriptor.Function(
-                    Index.ByIdentifier(Identifier.Function(null, null))
-                )
             )
-        ).inOrder()
+        )
+        assertThat(func.locals).isEmpty()
+        assertThat(func.instructions).isEmpty()
+        assertThat(export.name).isEqualTo("a")
+        assertThat(export.descriptor.index)
+            .isEqualTo(Index.ByIdentifier(func.id ?: fail("ID should be non-null")))
     }
 
     @Test

--- a/library/src/test/java/kwasm/format/text/module/WasmFunctionInlineImportTest.kt
+++ b/library/src/test/java/kwasm/format/text/module/WasmFunctionInlineImportTest.kt
@@ -107,18 +107,15 @@ class WasmFunctionInlineImportTest {
             ?: fail("Expected a result")
 
         assertThat(result.parseLength).isEqualTo(8)
-        assertThat(result.astNode).isEqualTo(
-            Import(
-                "a",
-                "b",
-                ImportDescriptor.Function(
-                    Identifier.Function(null, null),
-                    TypeUse(
-                        null,
-                        astNodeListOf(),
-                        astNodeListOf()
-                    )
-                )
+        assertThat(result.astNode.moduleName).isEqualTo("a")
+        assertThat(result.astNode.name).isEqualTo("b")
+        val descriptor = result.astNode.descriptor as ImportDescriptor.Function
+        assertThat(descriptor.id.stringRepr).isNotNull()
+        assertThat(descriptor.typeUse).isEqualTo(
+            TypeUse(
+                null,
+                astNodeListOf(),
+                astNodeListOf()
             )
         )
     }

--- a/library/src/test/java/kwasm/format/text/module/WasmFunctionTest.kt
+++ b/library/src/test/java/kwasm/format/text/module/WasmFunctionTest.kt
@@ -72,7 +72,7 @@ class WasmFunctionTest {
         val result = tokenizer.tokenize("(func)", context).parseWasmFunction(0)
             ?: fail("Expected a result")
         assertThat(result.parseLength).isEqualTo(3)
-        assertThat(result.astNode.id).isEqualTo(Identifier.Function(null, null))
+        assertThat(result.astNode.id).isNotNull()
         assertThat(result.astNode.typeUse).isEqualTo(
             TypeUse(null, astNodeListOf(), astNodeListOf())
         )
@@ -98,7 +98,7 @@ class WasmFunctionTest {
         val result = tokenizer.tokenize("(func (type $0))", context).parseWasmFunction(0)
             ?: fail("Expected a result")
         assertThat(result.parseLength).isEqualTo(7)
-        assertThat(result.astNode.id).isEqualTo(Identifier.Function(null, null))
+        assertThat(result.astNode.id).isNotNull()
         assertThat(result.astNode.typeUse).isEqualTo(
             TypeUse(
                 Index.ByIdentifier(Identifier.Type("$0")),
@@ -115,7 +115,7 @@ class WasmFunctionTest {
         val result = tokenizer.tokenize("(func (local i32) (local i32))", context)
             .parseWasmFunction(0) ?: fail("Expected a result")
         assertThat(result.parseLength).isEqualTo(11)
-        assertThat(result.astNode.id).isEqualTo(Identifier.Function(null, null))
+        assertThat(result.astNode.id).isNotNull()
         assertThat(result.astNode.typeUse).isEqualTo(
             TypeUse(
                 null,
@@ -135,7 +135,7 @@ class WasmFunctionTest {
         val result = tokenizer.tokenize("(func (unreachable))", context).parseWasmFunction(0)
             ?: fail("Expected a result")
         assertThat(result.parseLength).isEqualTo(6)
-        assertThat(result.astNode.id).isEqualTo(Identifier.Function(null, null))
+        assertThat(result.astNode.id).isNotNull()
         assertThat(result.astNode.typeUse).isEqualTo(
             TypeUse(
                 null,


### PR DESCRIPTION
Fixes #130 