### PR TITLE
Implement unary ops.

### DIFF
--- a/library/src/main/java/kwasm/runtime/instruction/Instruction.kt
+++ b/library/src/main/java/kwasm/runtime/instruction/Instruction.kt
@@ -16,6 +16,7 @@ package kwasm.runtime.instruction
 
 import kwasm.ast.instruction.Instruction
 import kwasm.ast.instruction.NumericConstantInstruction
+import kwasm.ast.instruction.NumericInstruction
 import kwasm.ast.instruction.VariableInstruction
 import kwasm.runtime.ExecutionContext
 
@@ -24,5 +25,6 @@ internal fun Instruction.execute(
 ): ExecutionContext = when (this) {
     is NumericConstantInstruction<*> -> this.execute(context)
     is VariableInstruction -> this.execute(context)
+    is NumericInstruction -> this.execute(context)
     else -> TODO("Instruction: $this not supported yet.")
 }

--- a/library/src/main/java/kwasm/runtime/instruction/NumericInstruction.kt
+++ b/library/src/main/java/kwasm/runtime/instruction/NumericInstruction.kt
@@ -16,6 +16,12 @@
 
 package kwasm.runtime.instruction
 
+import kotlin.math.absoluteValue
+import kotlin.math.ceil
+import kotlin.math.floor
+import kotlin.math.round
+import kotlin.math.sqrt
+import kotlin.math.truncate
 import kwasm.KWasmRuntimeException
 import kwasm.ast.instruction.NumericInstruction
 import kwasm.runtime.DoubleValue
@@ -25,12 +31,6 @@ import kwasm.runtime.IntValue
 import kwasm.runtime.LongValue
 import kwasm.runtime.Value
 import kwasm.runtime.toValue
-import kotlin.math.absoluteValue
-import kotlin.math.ceil
-import kotlin.math.floor
-import kotlin.math.round
-import kotlin.math.sqrt
-import kotlin.math.truncate
 
 /**
  * See
@@ -322,7 +322,7 @@ internal fun NumericInstruction.execute(context: ExecutionContext): ExecutionCon
  */
 internal inline fun <reified In : Value<*>, reified Out : Value<*>> unaryOp(
     executionContext: ExecutionContext,
-    op: (In) -> Out
+    crossinline op: (In) -> Out
 ): ExecutionContext {
     val stackTop = executionContext.stacks.operands.pop()
     if (stackTop !is In) throw KWasmRuntimeException("Top of stack is invalid type")

--- a/library/src/main/java/kwasm/runtime/instruction/NumericInstruction.kt
+++ b/library/src/main/java/kwasm/runtime/instruction/NumericInstruction.kt
@@ -1,0 +1,334 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("EXPERIMENTAL_UNSIGNED_LITERALS", "EXPERIMENTAL_API_USAGE")
+
+package kwasm.runtime.instruction
+
+import kwasm.KWasmRuntimeException
+import kwasm.ast.instruction.NumericInstruction
+import kwasm.runtime.DoubleValue
+import kwasm.runtime.ExecutionContext
+import kwasm.runtime.FloatValue
+import kwasm.runtime.IntValue
+import kwasm.runtime.LongValue
+import kwasm.runtime.Value
+import kwasm.runtime.toValue
+import kotlin.math.absoluteValue
+import kotlin.math.ceil
+import kotlin.math.floor
+import kotlin.math.round
+import kotlin.math.sqrt
+import kotlin.math.truncate
+
+/**
+ * See
+ * [the docs](https://webassembly.github.io/spec/core/exec/instructions.html#numeric-instructions):
+ */
+internal fun NumericInstruction.execute(context: ExecutionContext): ExecutionContext {
+    when (this) {
+        NumericInstruction.I32Add -> TODO()
+        NumericInstruction.I32CountLeadingZeroes -> unaryOp(context) { x: IntValue ->
+            if (x.value == 0) 32.toValue()
+            else {
+                var xVal = x.unsignedValue
+                var total = 0
+                var startWidth = 16
+                var mask = 0xFFFF0000u
+                while (startWidth > 0) {
+                    if (xVal and mask == 0u) {
+                        xVal = xVal shl startWidth
+                        total += startWidth
+                    }
+                    startWidth = startWidth ushr 1
+                    mask = mask shl startWidth
+                }
+                total.toValue()
+            }
+        }
+        NumericInstruction.I32CountTrailingZeroes -> unaryOp(context) { x: IntValue ->
+            if (x.value == 0) 32.toValue()
+            else {
+                var xVal = x.unsignedValue
+                var total = 0
+                var endWidth = 16
+                var mask = 0xFFFFu
+                while (endWidth > 0) {
+                    if (xVal and mask == 0u) {
+                        xVal = xVal shr endWidth
+                        total += endWidth
+                    }
+                    endWidth = endWidth ushr 1
+                    mask = mask shr endWidth
+                }
+                total.toValue()
+            }
+        }
+        NumericInstruction.I32CountNonZeroBits -> unaryOp(context) { x: IntValue ->
+            when (x.value) {
+                0 -> 0.toValue()
+                -1 -> 32.toValue()
+                else -> {
+                    var mask = 1
+                    var total = 0
+                    repeat(31) {
+                        if (mask and x.value != 0) total++
+                        mask = mask shl 1
+                    }
+                    total.toValue()
+                }
+            }
+        }
+        NumericInstruction.I32Subtract -> TODO()
+        NumericInstruction.I32Multiply -> TODO()
+        NumericInstruction.I32DivideSigned -> TODO()
+        NumericInstruction.I32DivideUnsigned -> TODO()
+        NumericInstruction.I32RemainderSigned -> TODO()
+        NumericInstruction.I32RemainderUnsigned -> TODO()
+        NumericInstruction.I32BitwiseAnd -> TODO()
+        NumericInstruction.I32BitwiseOr -> TODO()
+        NumericInstruction.I32BitwiseXor -> TODO()
+        NumericInstruction.I32ShiftLeft -> TODO()
+        NumericInstruction.I32ShiftRightSigned -> TODO()
+        NumericInstruction.I32ShiftRightUnsigned -> TODO()
+        NumericInstruction.I32RotateLeft -> TODO()
+        NumericInstruction.I32RotateRight -> TODO()
+        NumericInstruction.I32EqualsZero -> TODO()
+        NumericInstruction.I32Equals -> TODO()
+        NumericInstruction.I32NotEquals -> TODO()
+        NumericInstruction.I32LessThanSigned -> TODO()
+        NumericInstruction.I32LessThanUnsigned -> TODO()
+        NumericInstruction.I32GreaterThanSigned -> TODO()
+        NumericInstruction.I32GreaterThanUnsigned -> TODO()
+        NumericInstruction.I32LessThanEqualToSigned -> TODO()
+        NumericInstruction.I32LessThanEqualToUnsigned -> TODO()
+        NumericInstruction.I32GreaterThanEqualToSigned -> TODO()
+        NumericInstruction.I32GreaterThanEqualToUnsigned -> TODO()
+        NumericInstruction.I64CountLeadingZeroes -> unaryOp(context) { x: LongValue ->
+            if (x.value == 0L) 64L.toValue()
+            else {
+                var xVal = x.unsignedValue
+                var total = 0L
+                var mask = 0xFFFFFFFF00000000uL
+                var startWidth = 32
+                while (startWidth > 0) {
+                    if (xVal and mask == 0uL) {
+                        xVal = xVal shl startWidth
+                        total += startWidth
+                    }
+                    startWidth = startWidth ushr 1
+                    mask = mask shl startWidth
+                }
+                total.toValue()
+            }
+        }
+        NumericInstruction.I64CountTrailingZeroes -> unaryOp(context) { x: LongValue ->
+            if (x.value == 0L) 64L.toValue()
+            else {
+                var xVal = x.unsignedValue
+                var total = 0L
+                var endWidth = 32
+                var mask = 0xFFFFFFFFuL
+                while (endWidth > 0) {
+                    if (xVal and mask == 0uL) {
+                        xVal = xVal shr endWidth
+                        total += endWidth
+                    }
+                    endWidth = endWidth ushr 1
+                    mask = mask shr endWidth
+                }
+                total.toValue()
+            }
+        }
+        NumericInstruction.I64CountNonZeroBits -> unaryOp(context) { x: LongValue ->
+            when (x.value) {
+                0L -> 0L.toValue()
+                -1L -> 64L.toValue()
+                else -> {
+                    var mask = 1L
+                    var total = 0L
+                    repeat(63) {
+                        if (mask and x.value != 0L) total++
+                        mask = mask shl 1
+                    }
+                    total.toValue()
+                }
+            }
+        }
+        NumericInstruction.I64Add -> TODO()
+        NumericInstruction.I64Subtract -> TODO()
+        NumericInstruction.I64Multiply -> TODO()
+        NumericInstruction.I64DivideSigned -> TODO()
+        NumericInstruction.I64DivideUnsigned -> TODO()
+        NumericInstruction.I64RemainderSigned -> TODO()
+        NumericInstruction.I64RemainderUnsigned -> TODO()
+        NumericInstruction.I64BitwiseAnd -> TODO()
+        NumericInstruction.I64BitwiseOr -> TODO()
+        NumericInstruction.I64BitwiseXor -> TODO()
+        NumericInstruction.I64ShiftLeft -> TODO()
+        NumericInstruction.I64ShiftRightSigned -> TODO()
+        NumericInstruction.I64ShiftRightUnsigned -> TODO()
+        NumericInstruction.I64RotateLeft -> TODO()
+        NumericInstruction.I64RotateRight -> TODO()
+        NumericInstruction.I64EqualsZero -> TODO()
+        NumericInstruction.I64Equals -> TODO()
+        NumericInstruction.I64NotEquals -> TODO()
+        NumericInstruction.I64LessThanSigned -> TODO()
+        NumericInstruction.I64LessThanUnsigned -> TODO()
+        NumericInstruction.I64GreaterThanSigned -> TODO()
+        NumericInstruction.I64GreaterThanUnsigned -> TODO()
+        NumericInstruction.I64LessThanEqualToSigned -> TODO()
+        NumericInstruction.I64LessThanEqualToUnsigned -> TODO()
+        NumericInstruction.I64GreaterThanEqualToSigned -> TODO()
+        NumericInstruction.I64GreaterThanEqualToUnsigned -> TODO()
+        NumericInstruction.F32AbsoluteValue -> unaryOp(context) { x: FloatValue ->
+            x.value.absoluteValue.toValue()
+        }
+        NumericInstruction.F32Negative -> unaryOp(context) { x: FloatValue ->
+            (-x.value).toValue()
+        }
+        NumericInstruction.F32Ceiling -> unaryOp(context) { x: FloatValue ->
+            ceil(x.value).toValue()
+        }
+        NumericInstruction.F32Floor -> unaryOp(context) { x: FloatValue ->
+            floor(x.value).toValue()
+        }
+        NumericInstruction.F32Truncate -> unaryOp(context) { x: FloatValue ->
+            truncate(x.value).toValue()
+        }
+        NumericInstruction.F32Nearest -> unaryOp(context) { x: FloatValue ->
+            round(x.value).toValue()
+        }
+        NumericInstruction.F32SquareRoot -> unaryOp(context) { x: FloatValue ->
+            sqrt(x.value).toValue()
+        }
+        NumericInstruction.F32Add -> TODO()
+        NumericInstruction.F32Subtract -> TODO()
+        NumericInstruction.F32Multiply -> TODO()
+        NumericInstruction.F32Divide -> TODO()
+        NumericInstruction.F32Min -> TODO()
+        NumericInstruction.F32Max -> TODO()
+        NumericInstruction.F32CopySign -> TODO()
+        NumericInstruction.F32Equals -> TODO()
+        NumericInstruction.F32NotEquals -> TODO()
+        NumericInstruction.F32LessThan -> TODO()
+        NumericInstruction.F32GreaterThan -> TODO()
+        NumericInstruction.F32LessThanEqualTo -> TODO()
+        NumericInstruction.F32GreaterThanEqualTo -> TODO()
+        NumericInstruction.F64AbsoluteValue -> unaryOp(context) { x: DoubleValue ->
+            x.value.absoluteValue.toValue()
+        }
+        NumericInstruction.F64Negative -> unaryOp(context) { x: DoubleValue ->
+            (-x.value).toValue()
+        }
+        NumericInstruction.F64Ceiling -> unaryOp(context) { x: DoubleValue ->
+            ceil(x.value).toValue()
+        }
+        NumericInstruction.F64Floor -> unaryOp(context) { x: DoubleValue ->
+            floor(x.value).toValue()
+        }
+        NumericInstruction.F64Truncate -> unaryOp(context) { x: DoubleValue ->
+            truncate(x.value).toValue()
+        }
+        NumericInstruction.F64Nearest -> unaryOp(context) { x: DoubleValue ->
+            round(x.value).toValue()
+        }
+        NumericInstruction.F64SquareRoot -> unaryOp(context) { x: DoubleValue ->
+            sqrt(x.value).toValue()
+        }
+        NumericInstruction.F64Add -> TODO()
+        NumericInstruction.F64Subtract -> TODO()
+        NumericInstruction.F64Multiply -> TODO()
+        NumericInstruction.F64Divide -> TODO()
+        NumericInstruction.F64Min -> TODO()
+        NumericInstruction.F64Max -> TODO()
+        NumericInstruction.F64CopySign -> TODO()
+        NumericInstruction.F64Equals -> TODO()
+        NumericInstruction.F64NotEquals -> TODO()
+        NumericInstruction.F64LessThan -> TODO()
+        NumericInstruction.F64GreaterThan -> TODO()
+        NumericInstruction.F64LessThanEqualTo -> TODO()
+        NumericInstruction.F64GreaterThanEqualTo -> TODO()
+        NumericInstruction.I32WrapI64 -> TODO()
+        NumericInstruction.I32TruncateF32Signed -> TODO()
+        NumericInstruction.I32TruncateF32Unsigned -> TODO()
+        NumericInstruction.I32TruncateF64Signed -> TODO()
+        NumericInstruction.I32TruncateF64Unsigned -> TODO()
+        NumericInstruction.I32ReinterpretF32 -> TODO()
+        NumericInstruction.I64ExtendI32Signed -> TODO()
+        NumericInstruction.I64ExtendI32Unsigned -> TODO()
+        NumericInstruction.I64TruncateF32Signed -> TODO()
+        NumericInstruction.I64TruncateF32Unsigned -> TODO()
+        NumericInstruction.I64TruncateF64Signed -> TODO()
+        NumericInstruction.I64TruncateF64Unsigned -> TODO()
+        NumericInstruction.I64ReinterpretF64 -> TODO()
+        NumericInstruction.F32ConvertI32Signed -> TODO()
+        NumericInstruction.F32ConvertI32Unsigned -> TODO()
+        NumericInstruction.F32ConvertI64Signed -> TODO()
+        NumericInstruction.F32ConvertI64Unsigned -> TODO()
+        NumericInstruction.F32DemoteF64 -> TODO()
+        NumericInstruction.F32ReinterpretI32 -> TODO()
+        NumericInstruction.F64ConvertI32Signed -> TODO()
+        NumericInstruction.F64ConvertI32Unsigned -> TODO()
+        NumericInstruction.F64ConvertI64Signed -> TODO()
+        NumericInstruction.F64ConvertI64Unsigned -> TODO()
+        NumericInstruction.F64PromoteF32 -> TODO()
+        NumericInstruction.F64ReinterpretI64 -> TODO()
+    }
+    return context
+}
+
+/**
+ * From [the docs](https://webassembly.github.io/spec/core/exec/instructions.html#exec-unop):
+ *
+ * ```
+ *   t.unop
+ * ```
+ *
+ * 1. Assert: due to validation, a value of value type `t` is on the top of the stack.
+ * 1. Pop the value `t.const c_1` from the stack.
+ * 1. If `unopt(c_1)` is defined, then:
+ *    * Let `c` be a possible result of computing `unopt(c_1)`.
+ *    * Push the value `t.const c` to the stack.
+ * 1. Else:
+ *    * Trap.
+ *
+ * Also functions as the conversion operator util.
+ *
+ * From [the docs](https://webassembly.github.io/spec/core/exec/instructions.html#exec-cvtop):
+ *
+ * ```
+ *   t2.cvtop_t1_sx?
+ * ```
+ *
+ * 1. Assert: due to validation, a value of value type `t1` is on the top of the stack.
+ * 1. Pop the value `t1.const c1` from the stack.
+ * 1. If `cvtop^sx?_t1,_t2(c1)` is defined:
+ *    * Let `c_2` be a possible result of computing `cvtop^sx?_t1,_t2(c_1)`.
+ *    * Push the value `t_2.const c_2` to the stack.
+ * 1. Else:
+ *    * Trap.
+ */
+internal inline fun <reified In : Value<*>, reified Out : Value<*>> unaryOp(
+    executionContext: ExecutionContext,
+    op: (In) -> Out
+): ExecutionContext {
+    val stackTop = executionContext.stacks.operands.pop()
+    if (stackTop !is In) throw KWasmRuntimeException("Top of stack is invalid type")
+
+    val newTop = op(stackTop)
+    executionContext.stacks.operands.push(newTop)
+
+    return executionContext
+}

--- a/library/src/test/java/kwasm/runtime/instruction/NumericInstructionTest.kt
+++ b/library/src/test/java/kwasm/runtime/instruction/NumericInstructionTest.kt
@@ -15,20 +15,19 @@
 package kwasm.runtime.instruction
 
 import com.google.common.truth.Truth.assertThat
+import kotlin.math.sqrt
 import kwasm.KWasmRuntimeException
 import kwasm.ParseRule
 import kwasm.runtime.EmptyExecutionContext
 import kwasm.runtime.ExecutionContext
 import kwasm.runtime.IntValue
 import kwasm.runtime.Value
-import kwasm.runtime.stack.OperandStack
 import kwasm.runtime.toValue
 import org.junit.Assert.assertThrows
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
-import kotlin.math.sqrt
 
 @RunWith(JUnit4::class)
 class NumericInstructionTest {

--- a/library/src/test/java/kwasm/runtime/instruction/NumericInstructionTest.kt
+++ b/library/src/test/java/kwasm/runtime/instruction/NumericInstructionTest.kt
@@ -1,0 +1,723 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kwasm.runtime.instruction
+
+import com.google.common.truth.Truth.assertThat
+import kwasm.KWasmRuntimeException
+import kwasm.ParseRule
+import kwasm.runtime.EmptyExecutionContext
+import kwasm.runtime.ExecutionContext
+import kwasm.runtime.IntValue
+import kwasm.runtime.Value
+import kwasm.runtime.stack.OperandStack
+import kwasm.runtime.toValue
+import org.junit.Assert.assertThrows
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import kotlin.math.sqrt
+
+@RunWith(JUnit4::class)
+class NumericInstructionTest {
+    @get:Rule
+    val parser = ParseRule()
+
+    private val executionContext: ExecutionContext
+        get() = EmptyExecutionContext()
+
+    @Test
+    fun i32CountLeadingZeroes() = parser.with {
+        val instruction = "i32.clz".parseInstruction()
+
+        var resultContext = instruction.execute(executionContextWithOpStack(0.toValue()))
+        assertThat(resultContext).hasOpStackContaining(32.toValue())
+
+        var stackValue = 1
+        (1 until 32).forEach {
+            val expected = (32 - it).toValue()
+            resultContext = instruction.execute(executionContextWithOpStack(stackValue.toValue()))
+            assertThat(resultContext.stacks.operands.height).isEqualTo(1)
+            assertThat(resultContext.stacks.operands.peek()).isEqualTo(expected)
+            stackValue = stackValue shl 1
+        }
+    }
+
+    @Test
+    fun i32CountTrailingZeroes() = parser.with {
+        val instruction = "i32.ctz".parseInstruction()
+
+        var resultContext = instruction.execute(executionContextWithOpStack(0.toValue()))
+        assertThat(resultContext).hasOpStackContaining(32.toValue())
+
+        var stackValue = 1 shl 31
+        (1 until 32).forEach {
+            val expected = (32 - it).toValue()
+            resultContext = instruction.execute(executionContextWithOpStack(stackValue.toValue()))
+            assertThat(resultContext).hasOpStackContaining(expected)
+            stackValue = stackValue ushr 1
+        }
+    }
+
+    @Test
+    fun i32CountNonZeroBits() = parser.with {
+        val instruction = "i32.popcnt".parseInstruction()
+
+        var resultContext = instruction.execute(executionContextWithOpStack(0.toValue()))
+        assertThat(resultContext).hasOpStackContaining(0.toValue())
+
+        resultContext = instruction.execute(executionContextWithOpStack((-1).toValue()))
+        assertThat(resultContext).hasOpStackContaining(32.toValue())
+
+        var stackStartValue = 1
+        (1 until 32).forEach { expected ->
+            var stackValue = stackStartValue
+            // shift the stack value across the space
+            repeat(32 - expected) {
+                resultContext = instruction.execute(
+                    executionContextWithOpStack(stackValue.toValue())
+                )
+                assertThat(resultContext).hasOpStackContaining(expected.toValue())
+                stackValue = stackValue shl 1
+            }
+            // add a 1-bit to the stack start value
+            stackStartValue = (stackStartValue shl 1) or 1
+        }
+    }
+
+    @Test
+    fun i64CountLeadingZeroes() = parser.with {
+        val instruction = "i64.clz".parseInstruction()
+
+        var resultContext = instruction.execute(executionContextWithOpStack(0L.toValue()))
+        assertThat(resultContext.stacks.operands.height).isEqualTo(1)
+        assertThat(resultContext.stacks.operands.peek()).isEqualTo(64L.toValue())
+
+        var stackValue = 1L
+        (1 until 64).forEach {
+            val expected = (64 - it).toLong().toValue()
+            resultContext = instruction.execute(executionContextWithOpStack(stackValue.toValue()))
+            assertThat(resultContext.stacks.operands.height).isEqualTo(1)
+            assertThat(resultContext.stacks.operands.peek()).isEqualTo(expected)
+            stackValue = stackValue shl 1
+        }
+    }
+
+    @Test
+    fun i64CountTrailingZeroes() = parser.with {
+        val instruction = "i64.ctz".parseInstruction()
+
+        var resultContext = instruction.execute(executionContextWithOpStack(0L.toValue()))
+        assertThat(resultContext.stacks.operands.height).isEqualTo(1)
+        assertThat(resultContext.stacks.operands.peek()).isEqualTo(64L.toValue())
+
+        var stackValue = 1L shl 63
+        (1 until 64).forEach {
+            val expected = (64 - it).toLong().toValue()
+            resultContext = instruction.execute(executionContextWithOpStack(stackValue.toValue()))
+            assertThat(resultContext.stacks.operands.height).isEqualTo(1)
+            assertThat(resultContext.stacks.operands.peek()).isEqualTo(expected)
+            stackValue = stackValue ushr 1
+        }
+    }
+
+    @Test
+    fun i64CountNonZeroBits() = parser.with {
+        val instruction = "i64.popcnt".parseInstruction()
+
+        var resultContext = instruction.execute(executionContextWithOpStack(0L.toValue()))
+        assertThat(resultContext).hasOpStackContaining(0L.toValue())
+
+        resultContext = instruction.execute(executionContextWithOpStack((-1L).toValue()))
+        assertThat(resultContext).hasOpStackContaining(64L.toValue())
+
+        var stackStartValue = 1L
+        (1 until 64).forEach { expected ->
+            var stackValue = stackStartValue
+            // shift the stack value across the space
+            repeat(64 - expected) {
+                resultContext = instruction.execute(
+                    executionContextWithOpStack(stackValue.toValue())
+                )
+                assertThat(resultContext.stacks.operands.height).isEqualTo(1)
+                assertThat(resultContext.stacks.operands.pop())
+                    .isEqualTo(expected.toLong().toValue())
+                stackValue = stackValue shl 1
+            }
+            // add a 1-bit to the stack start value
+            stackStartValue = (stackStartValue shl 1) or 1
+        }
+    }
+
+    @Test
+    fun f32AbsoluteValue() = parser.with {
+        val instruction = "f32.abs".parseInstruction()
+
+        var resultContext = instruction.execute(
+            executionContextWithOpStack(Float.NEGATIVE_INFINITY.toValue())
+        )
+        assertThat(resultContext).hasOpStackContaining(Float.POSITIVE_INFINITY.toValue())
+
+        resultContext = instruction.execute(executionContextWithOpStack(0f.toValue()))
+        assertThat(resultContext).hasOpStackContaining(0f.toValue())
+
+        resultContext = instruction.execute(executionContextWithOpStack((-0f).toValue()))
+        assertThat(resultContext).hasOpStackContaining(0f.toValue())
+
+        resultContext = instruction.execute(executionContextWithOpStack((-1f).toValue()))
+        assertThat(resultContext).hasOpStackContaining(1f.toValue())
+
+        resultContext = instruction.execute(executionContextWithOpStack(1f.toValue()))
+        assertThat(resultContext).hasOpStackContaining(1f.toValue())
+    }
+
+    @Test
+    fun f32Negative() = parser.with {
+        val instruction = "f32.neg".parseInstruction()
+
+        var resultContext = instruction.execute(
+            executionContextWithOpStack(Float.NEGATIVE_INFINITY.toValue())
+        )
+        assertThat(resultContext).hasOpStackContaining(Float.POSITIVE_INFINITY.toValue())
+
+        resultContext = instruction.execute(
+            executionContextWithOpStack(Float.POSITIVE_INFINITY.toValue())
+        )
+        assertThat(resultContext).hasOpStackContaining(Float.NEGATIVE_INFINITY.toValue())
+
+        resultContext = instruction.execute(
+            executionContextWithOpStack(Float.NaN.toValue())
+        )
+        assertThat(resultContext).hasOpStackContaining((-Float.NaN).toValue())
+
+        resultContext = instruction.execute(
+            executionContextWithOpStack((-Float.NaN).toValue())
+        )
+        assertThat(resultContext).hasOpStackContaining(Float.NaN.toValue())
+
+        resultContext = instruction.execute(executionContextWithOpStack(0f.toValue()))
+        assertThat(resultContext).hasOpStackContaining((-0f).toValue())
+
+        resultContext = instruction.execute(executionContextWithOpStack((-0f).toValue()))
+        assertThat(resultContext).hasOpStackContaining(0f.toValue())
+
+        resultContext = instruction.execute(executionContextWithOpStack((-1f).toValue()))
+        assertThat(resultContext).hasOpStackContaining(1f.toValue())
+
+        resultContext = instruction.execute(executionContextWithOpStack((-1f).toValue()))
+        assertThat(resultContext).hasOpStackContaining(1f.toValue())
+    }
+
+    @Test
+    fun f32Ceil() = parser.with {
+        val instruction = "f32.ceil".parseInstruction()
+
+        var resultContext = instruction.execute(
+            executionContextWithOpStack(Float.NEGATIVE_INFINITY.toValue())
+        )
+        assertThat(resultContext).hasOpStackContaining(Float.NEGATIVE_INFINITY.toValue())
+
+        resultContext = instruction.execute(
+            executionContextWithOpStack(Float.POSITIVE_INFINITY.toValue())
+        )
+        assertThat(resultContext).hasOpStackContaining(Float.POSITIVE_INFINITY.toValue())
+
+        resultContext = instruction.execute(
+            executionContextWithOpStack(Float.NaN.toValue())
+        )
+        assertThat(resultContext).hasOpStackContaining(Float.NaN.toValue())
+
+        resultContext = instruction.execute(
+            executionContextWithOpStack((-Float.NaN).toValue())
+        )
+        assertThat(resultContext).hasOpStackContaining((-Float.NaN).toValue())
+
+        resultContext = instruction.execute(executionContextWithOpStack(0.0f.toValue()))
+        assertThat(resultContext).hasOpStackContaining(0.0f.toValue())
+
+        resultContext = instruction.execute(executionContextWithOpStack((-0.0f).toValue()))
+        assertThat(resultContext).hasOpStackContaining((-0.0f).toValue())
+
+        resultContext = instruction.execute(executionContextWithOpStack((-0.1f).toValue()))
+        assertThat(resultContext).hasOpStackContaining((-0.0f).toValue())
+
+        resultContext = instruction.execute(executionContextWithOpStack(0.1f.toValue()))
+        assertThat(resultContext).hasOpStackContaining(1.0f.toValue())
+    }
+
+    @Test
+    fun f32Floor() = parser.with {
+        val instruction = "f32.floor".parseInstruction()
+
+        var resultContext = instruction.execute(
+            executionContextWithOpStack(Float.NEGATIVE_INFINITY.toValue())
+        )
+        assertThat(resultContext).hasOpStackContaining(Float.NEGATIVE_INFINITY.toValue())
+
+        resultContext = instruction.execute(
+            executionContextWithOpStack(Float.POSITIVE_INFINITY.toValue())
+        )
+        assertThat(resultContext).hasOpStackContaining(Float.POSITIVE_INFINITY.toValue())
+
+        resultContext = instruction.execute(
+            executionContextWithOpStack(Float.NaN.toValue())
+        )
+        assertThat(resultContext).hasOpStackContaining(Float.NaN.toValue())
+
+        resultContext = instruction.execute(
+            executionContextWithOpStack((-Float.NaN).toValue())
+        )
+        assertThat(resultContext).hasOpStackContaining((-Float.NaN).toValue())
+
+        resultContext = instruction.execute(executionContextWithOpStack(0.0f.toValue()))
+        assertThat(resultContext).hasOpStackContaining(0.0f.toValue())
+
+        resultContext = instruction.execute(executionContextWithOpStack((-0.0f).toValue()))
+        assertThat(resultContext).hasOpStackContaining((-0.0f).toValue())
+
+        resultContext = instruction.execute(executionContextWithOpStack((-0.1f).toValue()))
+        assertThat(resultContext).hasOpStackContaining((-1.0f).toValue())
+
+        resultContext = instruction.execute(executionContextWithOpStack(0.1f.toValue()))
+        assertThat(resultContext).hasOpStackContaining(0.0f.toValue())
+    }
+
+    @Test
+    fun f32Truncate() = parser.with {
+        val instruction = "f32.trunc".parseInstruction()
+
+        var resultContext = instruction.execute(
+            executionContextWithOpStack(Float.NEGATIVE_INFINITY.toValue())
+        )
+        assertThat(resultContext).hasOpStackContaining(Float.NEGATIVE_INFINITY.toValue())
+
+        resultContext = instruction.execute(
+            executionContextWithOpStack(Float.POSITIVE_INFINITY.toValue())
+        )
+        assertThat(resultContext).hasOpStackContaining(Float.POSITIVE_INFINITY.toValue())
+
+        resultContext = instruction.execute(
+            executionContextWithOpStack(Float.NaN.toValue())
+        )
+        assertThat(resultContext).hasOpStackContaining(Float.NaN.toValue())
+
+        resultContext = instruction.execute(
+            executionContextWithOpStack((-Float.NaN).toValue())
+        )
+        assertThat(resultContext).hasOpStackContaining((-Float.NaN).toValue())
+
+        resultContext = instruction.execute(executionContextWithOpStack(0.0f.toValue()))
+        assertThat(resultContext).hasOpStackContaining(0.0f.toValue())
+
+        resultContext = instruction.execute(executionContextWithOpStack((-0.0f).toValue()))
+        assertThat(resultContext).hasOpStackContaining((-0.0f).toValue())
+
+        resultContext = instruction.execute(executionContextWithOpStack((-0.1f).toValue()))
+        assertThat(resultContext).hasOpStackContaining((-0.0f).toValue())
+
+        resultContext = instruction.execute(executionContextWithOpStack(0.1f.toValue()))
+        assertThat(resultContext).hasOpStackContaining(0.0f.toValue())
+
+        resultContext = instruction.execute(executionContextWithOpStack(1.1f.toValue()))
+        assertThat(resultContext).hasOpStackContaining(1.0f.toValue())
+
+        resultContext = instruction.execute(executionContextWithOpStack((-1.1f).toValue()))
+        assertThat(resultContext).hasOpStackContaining((-1.0f).toValue())
+    }
+
+    @Test
+    fun f32Nearest() = parser.with {
+        val instruction = "f32.nearest".parseInstruction()
+
+        var resultContext = instruction.execute(
+            executionContextWithOpStack(Float.NEGATIVE_INFINITY.toValue())
+        )
+        assertThat(resultContext).hasOpStackContaining(Float.NEGATIVE_INFINITY.toValue())
+
+        resultContext = instruction.execute(
+            executionContextWithOpStack(Float.POSITIVE_INFINITY.toValue())
+        )
+        assertThat(resultContext).hasOpStackContaining(Float.POSITIVE_INFINITY.toValue())
+
+        resultContext = instruction.execute(
+            executionContextWithOpStack(Float.NaN.toValue())
+        )
+        assertThat(resultContext).hasOpStackContaining(Float.NaN.toValue())
+
+        resultContext = instruction.execute(
+            executionContextWithOpStack((-Float.NaN).toValue())
+        )
+        assertThat(resultContext).hasOpStackContaining((-Float.NaN).toValue())
+
+        resultContext = instruction.execute(executionContextWithOpStack(0.0f.toValue()))
+        assertThat(resultContext).hasOpStackContaining(0.0f.toValue())
+
+        resultContext = instruction.execute(executionContextWithOpStack((-0.0f).toValue()))
+        assertThat(resultContext).hasOpStackContaining((-0.0f).toValue())
+
+        resultContext = instruction.execute(executionContextWithOpStack((-0.1f).toValue()))
+        assertThat(resultContext).hasOpStackContaining((-0.0f).toValue())
+
+        resultContext = instruction.execute(executionContextWithOpStack(0.1f.toValue()))
+        assertThat(resultContext).hasOpStackContaining(0.0f.toValue())
+
+        resultContext = instruction.execute(executionContextWithOpStack(1.5f.toValue()))
+        assertThat(resultContext).hasOpStackContaining(2.0f.toValue())
+
+        resultContext = instruction.execute(executionContextWithOpStack((-1.5f).toValue()))
+        assertThat(resultContext).hasOpStackContaining((-2.0f).toValue())
+    }
+
+    @Test
+    fun f32SquareRoot() = parser.with {
+        val instruction = "f32.sqrt".parseInstruction()
+
+        var resultContext = instruction.execute(
+            executionContextWithOpStack(Float.NEGATIVE_INFINITY.toValue())
+        )
+        assertThat(resultContext).hasOpStackContaining(Float.NaN.toValue())
+
+        resultContext = instruction.execute(
+            executionContextWithOpStack(Float.POSITIVE_INFINITY.toValue())
+        )
+        assertThat(resultContext).hasOpStackContaining(Float.POSITIVE_INFINITY.toValue())
+
+        resultContext = instruction.execute(
+            executionContextWithOpStack(Float.NaN.toValue())
+        )
+        assertThat(resultContext).hasOpStackContaining(Float.NaN.toValue())
+
+        resultContext = instruction.execute(
+            executionContextWithOpStack((-Float.NaN).toValue())
+        )
+        assertThat(resultContext).hasOpStackContaining((-Float.NaN).toValue())
+
+        resultContext = instruction.execute(executionContextWithOpStack(0.0f.toValue()))
+        assertThat(resultContext).hasOpStackContaining(0.0f.toValue())
+
+        resultContext = instruction.execute(executionContextWithOpStack((-0.0f).toValue()))
+        assertThat(resultContext).hasOpStackContaining((-0.0f).toValue())
+
+        resultContext = instruction.execute(executionContextWithOpStack((-0.1f).toValue()))
+        assertThat(resultContext).hasOpStackContaining((-Float.NaN).toValue())
+
+        resultContext = instruction.execute(executionContextWithOpStack(0.1f.toValue()))
+        assertThat(resultContext).hasOpStackContaining(sqrt(0.1f).toValue())
+    }
+
+    @Test
+    fun f64AbsoluteValue() = parser.with {
+        val instruction = "f64.abs".parseInstruction()
+
+        var resultContext = instruction.execute(
+            executionContextWithOpStack(Double.NEGATIVE_INFINITY.toValue())
+        )
+        assertThat(resultContext).hasOpStackContaining(Double.POSITIVE_INFINITY.toValue())
+
+        resultContext = instruction.execute(executionContextWithOpStack(0.0.toValue()))
+        assertThat(resultContext).hasOpStackContaining(0.0.toValue())
+
+        resultContext = instruction.execute(executionContextWithOpStack((-0.0).toValue()))
+        assertThat(resultContext).hasOpStackContaining(0.0.toValue())
+
+        resultContext = instruction.execute(executionContextWithOpStack((-1.0).toValue()))
+        assertThat(resultContext).hasOpStackContaining(1.0.toValue())
+
+        resultContext = instruction.execute(executionContextWithOpStack(1.0.toValue()))
+        assertThat(resultContext).hasOpStackContaining(1.0.toValue())
+    }
+
+    @Test
+    fun f64Negative() = parser.with {
+        val instruction = "f64.neg".parseInstruction()
+
+        var resultContext = instruction.execute(
+            executionContextWithOpStack(Double.NEGATIVE_INFINITY.toValue())
+        )
+        assertThat(resultContext).hasOpStackContaining(Double.POSITIVE_INFINITY.toValue())
+
+        resultContext = instruction.execute(
+            executionContextWithOpStack(Double.POSITIVE_INFINITY.toValue())
+        )
+        assertThat(resultContext).hasOpStackContaining(Double.NEGATIVE_INFINITY.toValue())
+
+        resultContext = instruction.execute(
+            executionContextWithOpStack(Double.NaN.toValue())
+        )
+        assertThat(resultContext).hasOpStackContaining((-Double.NaN).toValue())
+
+        resultContext = instruction.execute(
+            executionContextWithOpStack((-Double.NaN).toValue())
+        )
+        assertThat(resultContext).hasOpStackContaining(Double.NaN.toValue())
+
+        resultContext = instruction.execute(executionContextWithOpStack(0.0.toValue()))
+        assertThat(resultContext).hasOpStackContaining((-0.0).toValue())
+
+        resultContext = instruction.execute(executionContextWithOpStack((-0.0).toValue()))
+        assertThat(resultContext).hasOpStackContaining(0.0.toValue())
+
+        resultContext = instruction.execute(executionContextWithOpStack((-1.0).toValue()))
+        assertThat(resultContext).hasOpStackContaining(1.0.toValue())
+
+        resultContext = instruction.execute(executionContextWithOpStack((-1.0).toValue()))
+        assertThat(resultContext).hasOpStackContaining(1.0.toValue())
+    }
+
+    @Test
+    fun f64Ceil() = parser.with {
+        val instruction = "f64.ceil".parseInstruction()
+
+        var resultContext = instruction.execute(
+            executionContextWithOpStack(Double.NEGATIVE_INFINITY.toValue())
+        )
+        assertThat(resultContext).hasOpStackContaining(Double.NEGATIVE_INFINITY.toValue())
+
+        resultContext = instruction.execute(
+            executionContextWithOpStack(Double.POSITIVE_INFINITY.toValue())
+        )
+        assertThat(resultContext.stacks.operands.height).isEqualTo(1)
+        assertThat(resultContext.stacks.operands.pop())
+            .isEqualTo(Double.POSITIVE_INFINITY.toValue())
+
+        resultContext = instruction.execute(
+            executionContextWithOpStack(Double.NaN.toValue())
+        )
+        assertThat(resultContext).hasOpStackContaining(Double.NaN.toValue())
+
+        resultContext = instruction.execute(
+            executionContextWithOpStack((-Double.NaN).toValue())
+        )
+        assertThat(resultContext).hasOpStackContaining((-Double.NaN).toValue())
+
+        resultContext = instruction.execute(executionContextWithOpStack(0.0.toValue()))
+        assertThat(resultContext).hasOpStackContaining(0.0.toValue())
+
+        resultContext = instruction.execute(executionContextWithOpStack((-0.0).toValue()))
+        assertThat(resultContext).hasOpStackContaining((-0.0).toValue())
+
+        resultContext = instruction.execute(executionContextWithOpStack((-0.1).toValue()))
+        assertThat(resultContext).hasOpStackContaining((-0.0).toValue())
+
+        resultContext = instruction.execute(executionContextWithOpStack(0.1.toValue()))
+        assertThat(resultContext).hasOpStackContaining(1.0.toValue())
+    }
+
+    @Test
+    fun f64Floor() = parser.with {
+        val instruction = "f64.floor".parseInstruction()
+
+        var resultContext = instruction.execute(
+            executionContextWithOpStack(Double.NEGATIVE_INFINITY.toValue())
+        )
+        assertThat(resultContext).hasOpStackContaining(Double.NEGATIVE_INFINITY.toValue())
+
+        resultContext = instruction.execute(
+            executionContextWithOpStack(Double.POSITIVE_INFINITY.toValue())
+        )
+        assertThat(resultContext).hasOpStackContaining(Double.POSITIVE_INFINITY.toValue())
+
+        resultContext = instruction.execute(
+            executionContextWithOpStack(Double.NaN.toValue())
+        )
+        assertThat(resultContext).hasOpStackContaining(Double.NaN.toValue())
+
+        resultContext = instruction.execute(
+            executionContextWithOpStack((-Double.NaN).toValue())
+        )
+        assertThat(resultContext).hasOpStackContaining((-Double.NaN).toValue())
+
+        resultContext = instruction.execute(executionContextWithOpStack(0.0.toValue()))
+        assertThat(resultContext).hasOpStackContaining(0.0.toValue())
+
+        resultContext = instruction.execute(executionContextWithOpStack((-0.0).toValue()))
+        assertThat(resultContext).hasOpStackContaining((-0.0).toValue())
+
+        resultContext = instruction.execute(executionContextWithOpStack((-0.1).toValue()))
+        assertThat(resultContext).hasOpStackContaining((-1.0).toValue())
+
+        resultContext = instruction.execute(executionContextWithOpStack(0.1.toValue()))
+        assertThat(resultContext).hasOpStackContaining(0.0.toValue())
+    }
+
+    @Test
+    fun f64Truncate() = parser.with {
+        val instruction = "f64.trunc".parseInstruction()
+
+        var resultContext = instruction.execute(
+            executionContextWithOpStack(Double.NEGATIVE_INFINITY.toValue())
+        )
+        assertThat(resultContext).hasOpStackContaining(Double.NEGATIVE_INFINITY.toValue())
+
+        resultContext = instruction.execute(
+            executionContextWithOpStack(Double.POSITIVE_INFINITY.toValue())
+        )
+        assertThat(resultContext).hasOpStackContaining(Double.POSITIVE_INFINITY.toValue())
+
+        resultContext = instruction.execute(
+            executionContextWithOpStack(Double.NaN.toValue())
+        )
+        assertThat(resultContext).hasOpStackContaining(Double.NaN.toValue())
+
+        resultContext = instruction.execute(
+            executionContextWithOpStack((-Double.NaN).toValue())
+        )
+        assertThat(resultContext).hasOpStackContaining((-Double.NaN).toValue())
+
+        resultContext = instruction.execute(executionContextWithOpStack(0.0.toValue()))
+        assertThat(resultContext).hasOpStackContaining(0.0.toValue())
+
+        resultContext = instruction.execute(executionContextWithOpStack((-0.0).toValue()))
+        assertThat(resultContext).hasOpStackContaining((-0.0).toValue())
+
+        resultContext = instruction.execute(executionContextWithOpStack((-0.1).toValue()))
+        assertThat(resultContext).hasOpStackContaining((-0.0).toValue())
+
+        resultContext = instruction.execute(executionContextWithOpStack(0.1.toValue()))
+        assertThat(resultContext).hasOpStackContaining(0.0.toValue())
+
+        resultContext = instruction.execute(executionContextWithOpStack(1.1.toValue()))
+        assertThat(resultContext).hasOpStackContaining(1.0.toValue())
+
+        resultContext = instruction.execute(executionContextWithOpStack((-1.1).toValue()))
+        assertThat(resultContext).hasOpStackContaining((-1.0).toValue())
+    }
+
+    @Test
+    fun f64Nearest() = parser.with {
+        val instruction = "f64.nearest".parseInstruction()
+
+        var resultContext = instruction.execute(
+            executionContextWithOpStack(Double.NEGATIVE_INFINITY.toValue())
+        )
+        assertThat(resultContext).hasOpStackContaining(Double.NEGATIVE_INFINITY.toValue())
+
+        resultContext = instruction.execute(
+            executionContextWithOpStack(Double.POSITIVE_INFINITY.toValue())
+        )
+        assertThat(resultContext).hasOpStackContaining(Double.POSITIVE_INFINITY.toValue())
+
+        resultContext = instruction.execute(
+            executionContextWithOpStack(Double.NaN.toValue())
+        )
+        assertThat(resultContext).hasOpStackContaining(Double.NaN.toValue())
+
+        resultContext = instruction.execute(
+            executionContextWithOpStack((-Double.NaN).toValue())
+        )
+        assertThat(resultContext).hasOpStackContaining((-Double.NaN).toValue())
+
+        resultContext = instruction.execute(executionContextWithOpStack(0.0.toValue()))
+        assertThat(resultContext).hasOpStackContaining(0.0.toValue())
+
+        resultContext = instruction.execute(executionContextWithOpStack((-0.0).toValue()))
+        assertThat(resultContext).hasOpStackContaining((-0.0).toValue())
+
+        resultContext = instruction.execute(executionContextWithOpStack((-0.1).toValue()))
+        assertThat(resultContext).hasOpStackContaining((-0.0).toValue())
+
+        resultContext = instruction.execute(executionContextWithOpStack(0.1.toValue()))
+        assertThat(resultContext).hasOpStackContaining(0.0.toValue())
+
+        resultContext = instruction.execute(executionContextWithOpStack(1.5.toValue()))
+        assertThat(resultContext).hasOpStackContaining(2.0.toValue())
+
+        resultContext = instruction.execute(executionContextWithOpStack((-1.5).toValue()))
+        assertThat(resultContext).hasOpStackContaining((-2.0).toValue())
+    }
+
+    @Test
+    fun f64SquareRoot() = parser.with {
+        val instruction = "f64.sqrt".parseInstruction()
+
+        var resultContext = instruction.execute(
+            executionContextWithOpStack(Double.NEGATIVE_INFINITY.toValue())
+        )
+        assertThat(resultContext).hasOpStackContaining(Double.NaN.toValue())
+
+        resultContext = instruction.execute(
+            executionContextWithOpStack(Double.POSITIVE_INFINITY.toValue())
+        )
+        assertThat(resultContext).hasOpStackContaining(Double.POSITIVE_INFINITY.toValue())
+
+        resultContext = instruction.execute(
+            executionContextWithOpStack(Double.NaN.toValue())
+        )
+        assertThat(resultContext).hasOpStackContaining(Double.NaN.toValue())
+
+        resultContext = instruction.execute(
+            executionContextWithOpStack((-Double.NaN).toValue())
+        )
+        assertThat(resultContext).hasOpStackContaining((-Double.NaN).toValue())
+
+        resultContext = instruction.execute(executionContextWithOpStack(0.0.toValue()))
+        assertThat(resultContext).hasOpStackContaining(0.0.toValue())
+
+        resultContext = instruction.execute(executionContextWithOpStack((-0.0).toValue()))
+        assertThat(resultContext).hasOpStackContaining((-0.0).toValue())
+
+        resultContext = instruction.execute(executionContextWithOpStack((-0.1).toValue()))
+        assertThat(resultContext).hasOpStackContaining((-Double.NaN).toValue())
+
+        resultContext = instruction.execute(executionContextWithOpStack(0.1.toValue()))
+        assertThat(resultContext).hasOpStackContaining(sqrt(0.1).toValue())
+    }
+
+    @Test
+    fun unaryOp_throws_ifStackEmpty() {
+        assertThrows(IllegalStateException::class.java) {
+            unaryOp<IntValue, IntValue>(executionContext) {
+                1.toValue()
+            }
+        }
+    }
+
+    @Test
+    fun unaryOp_throws_ifStackTopInvalidType() {
+        assertThrows(KWasmRuntimeException::class.java) {
+            unaryOp<IntValue, IntValue>(executionContextWithOpStack(42L.toValue())) {
+                1.toValue()
+            }
+        }.also {
+            assertThat(it).hasMessageThat().contains("Top of stack is invalid type")
+        }
+    }
+
+    @Test
+    fun unaryOp_valid() {
+        val result = unaryOp<IntValue, IntValue>(executionContextWithOpStack(13.toValue())) {
+            42.toValue()
+        }
+        assertThat(result).hasOpStackContaining(42.toValue())
+    }
+
+    private fun assertThat(context: ExecutionContext) = object {
+        fun hasOpStackContaining(vararg vals: Value<*>) {
+            val stack = mutableListOf<Value<*>>()
+            while (context.stacks.operands.peek() != null) {
+                stack += context.stacks.operands.pop()
+            }
+            stack.reverse()
+            assertThat(stack).containsExactly(*vals).inOrder()
+        }
+    }
+
+    private fun executionContextWithOpStack(vararg stackVals: Value<*>) =
+        executionContext.also {
+            stackVals.forEach { stackVal ->
+                it.stacks.operands.push(stackVal)
+            }
+        }
+}


### PR DESCRIPTION
Related Issue(s): #140 

Implements `iunop` and `funop` instruction execution, where `iunop` and `funop` instructions are defined at: https://webassembly.github.io/spec/core/syntax/instructions.html#numeric-instructions