### PR TITLE
Fix parsing of inf and nan for FloatLiterals.

### DIFF
--- a/library/src/main/java/kwasm/format/text/Tokenizer.kt
+++ b/library/src/main/java/kwasm/format/text/Tokenizer.kt
@@ -86,23 +86,23 @@ class Tokenizer {
         token.sequence.isEmpty() -> emptyList()
         // If the entire sequence is whitespace, we can ignore it.
         Format.PATTERN.get().matchEntire(token.sequence) != null -> emptyList()
-        token.isKeyword() -> listOf(token.toKeyword())
         token.isIntegerLiteral() -> listOf(token.toIntegerLiteral())
         token.isFloatLiteral() -> listOf(token.toFloatLiteral())
         token.isStringLiteral() -> listOf(token.toStringLiteral())
         token.isIdentifier() -> listOf(token.toIdentifier())
+        token.isKeyword() -> listOf(token.toKeyword())
         token.isOpenParen() || token.isClosedParen() -> listOf(token.toParen())
         token.isReserved() -> listOf(token.toReserved())
         else -> {
             val maxLengthTokenFind = listOf(
-                token.findKeyword(),
                 token.findStringLiteral(),
                 token.findIntegerLiteral(),
                 token.findFloatLiteral(),
+                token.findKeyword(),
                 token.findIdentifier(),
                 token.findParen(),
                 token.findReserved()
-            ).maxBy { it?.sequence?.length ?: -1 }.takeIf { it != null }
+            ).maxByOrNull { it?.sequence?.length ?: -1 }
                 ?: throw ParseException(
                     "No valid token found in sequence: \"${token.sequence}\"",
                     token.context

--- a/library/src/main/java/kwasm/format/text/token/FloatLiteral.kt
+++ b/library/src/main/java/kwasm/format/text/token/FloatLiteral.kt
@@ -51,7 +51,7 @@ import kotlin.math.pow
  *                'nan:0x' n:hexnum                                   => NaN (if 1 <= n < 2^(sig(N))
  * ```
  */
-@UseExperimental(ExperimentalUnsignedTypes::class)
+@OptIn(ExperimentalUnsignedTypes::class)
 class FloatLiteral(
     private val sequence: CharSequence,
     magnitude: Int = NumberConstants.DEFAULT_FLOAT_MAGNITUDE,
@@ -65,7 +65,12 @@ class FloatLiteral(
 
     val value: Double by lazy {
         when {
-            sequence == INFINITY_LITERAL -> INFINITY_VALUE
+            sequence == INFINITY_LITERAL ->
+                if (magnitude == 32) Float.POSITIVE_INFINITY.toDouble()
+                else Double.POSITIVE_INFINITY
+            sequence == "-$INFINITY_LITERAL" ->
+                if (magnitude == 32) Float.NEGATIVE_INFINITY.toDouble()
+                else Double.NEGATIVE_INFINITY
             sequence == NAN_LITERAL -> if (magnitude == 32) NAN_32_VALUE else NAN_64_VALUE
             sequence.startsWith(HEXNAN_LITERAL_PREFIX) -> {
                 val n = Num(
@@ -97,12 +102,18 @@ class FloatLiteral(
     }
 
     fun isNaN(): Boolean = when (magnitude) {
-        32 -> value == NAN_32_VALUE
-        64 -> value == NAN_64_VALUE
+        32 -> value.isNaN() || value == CanonincalNaN(32).value.toDouble()
+        64 -> value.isNaN() || value == CanonincalNaN(64).value.toDouble()
         else -> throw ParseException("Illegal magnitude for NaN-checking")
     }
 
-    fun isInfinite(): Boolean = value == INFINITY_VALUE
+    fun isInfinite(): Boolean = when (magnitude) {
+        32 ->
+            value == Float.NEGATIVE_INFINITY.toDouble() ||
+                value == Float.POSITIVE_INFINITY.toDouble()
+        64 -> value == Double.NEGATIVE_INFINITY || value == Double.POSITIVE_INFINITY
+        else -> throw ParseException("Illegal magnitude for infinity-checking")
+    }
 
     private fun determineFloatValue(
         sequence: CharSequence,
@@ -288,9 +299,8 @@ class FloatLiteral(
         private const val INFINITY_LITERAL = "inf"
         private const val NAN_LITERAL = "nan"
         private const val HEXNAN_LITERAL_PREFIX = "nan:0x"
-        private val INFINITY_VALUE = Double.POSITIVE_INFINITY
-        private val NAN_64_VALUE = CanonincalNaN(64).value.toDouble()
-        private val NAN_32_VALUE = CanonincalNaN(32).value.toDouble()
+        private const val NAN_64_VALUE = Double.NaN
+        private const val NAN_32_VALUE = Float.NaN.toDouble()
 
         private fun assertNoHexChars(context: ParseContext?, vararg components: Any) {
             val foundHexChars = components.any {
@@ -305,7 +315,7 @@ class FloatLiteral(
 
 fun RawToken.findFloatLiteral(): TokenMatchResult? {
     val match =
-        FloatLiteral.PATTERN.get().findAll(sequence).maxBy { it.value.length } ?: return null
+        FloatLiteral.PATTERN.get().findAll(sequence).maxByOrNull { it.value.length } ?: return null
     return TokenMatchResult(match.range.first, match.value)
 }
 

--- a/library/src/main/java/kwasm/format/text/token/IntegerLiteral.kt
+++ b/library/src/main/java/kwasm/format/text/token/IntegerLiteral.kt
@@ -143,7 +143,7 @@ sealed class IntegerLiteral<Type>(
         }
 
         override fun checkMagnitude(value: Long, magnitude: Int): Boolean {
-            if (magnitude == 32) return value in Int.MIN_VALUE..Int.MAX_VALUE
+            if (magnitude == 32) return value.toUInt().toInt() in Int.MIN_VALUE..Int.MAX_VALUE
             if (magnitude == 64) return value in Long.MIN_VALUE..Long.MAX_VALUE
             val doubleValue = value.toDouble()
             val extent = 2.0.pow(magnitude - 1)

--- a/library/src/main/java/kwasm/format/text/token/Keyword.kt
+++ b/library/src/main/java/kwasm/format/text/token/Keyword.kt
@@ -48,7 +48,8 @@ data class Keyword(
 }
 
 fun RawToken.findKeyword(): TokenMatchResult? {
-    val match = Keyword.PATTERN.get().findAll(sequence).maxBy { it.value.length } ?: return null
+    val match = Keyword.PATTERN.get().findAll(sequence).maxByOrNull { it.value.length } ?: return null
+    if (match.value == "inf" || match.value == "nan") return null
     return TokenMatchResult(match.range.first, match.value)
 }
 

--- a/library/src/main/java/kwasm/format/text/token/Reserved.kt
+++ b/library/src/main/java/kwasm/format/text/token/Reserved.kt
@@ -47,7 +47,9 @@ data class Reserved(
 }
 
 fun RawToken.findReserved(): TokenMatchResult? {
-    val match = Reserved.PATTERN.get().findAll(sequence).maxBy { it.value.length } ?: return null
+    val match = Reserved.PATTERN.get().findAll(sequence).maxByOrNull { it.value.length }
+        ?: return null
+    if (match.value == "inf" || match.value == "nan") return null
     return TokenMatchResult(match.range.first, match.value)
 }
 

--- a/library/src/test/java/kwasm/format/text/instruction/NumericConstantInstructionTest.kt
+++ b/library/src/test/java/kwasm/format/text/instruction/NumericConstantInstructionTest.kt
@@ -91,6 +91,33 @@ class NumericConstantInstructionTest {
     }
 
     @Test
+    fun f32Const_followedByNan() {
+        val result = tokenizer.tokenize("f32.const nan", context)
+            .parseNumericConstant(0) ?: fail("Expected an instruction")
+        assertThat(result.parseLength).isEqualTo(2)
+        val instruction = result.astNode as NumericConstantInstruction.F32
+        assertThat(instruction.value.value).isEqualTo(Float.NaN)
+    }
+
+    @Test
+    fun f32Const_followedByInf() {
+        val result = tokenizer.tokenize("f32.const inf", context)
+            .parseNumericConstant(0) ?: fail("Expected an instruction")
+        assertThat(result.parseLength).isEqualTo(2)
+        val instruction = result.astNode as NumericConstantInstruction.F32
+        assertThat(instruction.value.value).isEqualTo(Float.POSITIVE_INFINITY)
+    }
+
+    @Test
+    fun f32Const_followedByNegativeInf() {
+        val result = tokenizer.tokenize("f32.const -inf", context)
+            .parseNumericConstant(0) ?: fail("Expected an instruction")
+        assertThat(result.parseLength).isEqualTo(2)
+        val instruction = result.astNode as NumericConstantInstruction.F32
+        assertThat(instruction.value.value).isEqualTo(Float.NEGATIVE_INFINITY)
+    }
+
+    @Test
     fun parses_f64Const() {
         val result = tokenizer.tokenize("f64.const -1.5e5", context)
             .parseNumericConstant(0) ?: fail("Expected an instruction")
@@ -105,5 +132,32 @@ class NumericConstantInstructionTest {
             tokenizer.tokenize("f64.const 1", context)
                 .parseNumericConstant(0)
         }
+    }
+
+    @Test
+    fun f64Const_followedByNan() {
+        val result = tokenizer.tokenize("f64.const nan", context)
+            .parseNumericConstant(0) ?: fail("Expected an instruction")
+        assertThat(result.parseLength).isEqualTo(2)
+        val instruction = result.astNode as NumericConstantInstruction.F64
+        assertThat(instruction.value.value).isEqualTo(Double.NaN)
+    }
+
+    @Test
+    fun f64Const_followedByInf() {
+        val result = tokenizer.tokenize("f64.const inf", context)
+            .parseNumericConstant(0) ?: fail("Expected an instruction")
+        assertThat(result.parseLength).isEqualTo(2)
+        val instruction = result.astNode as NumericConstantInstruction.F64
+        assertThat(instruction.value.value).isEqualTo(Double.POSITIVE_INFINITY)
+    }
+
+    @Test
+    fun f64Const_followedByNegativeInf() {
+        val result = tokenizer.tokenize("f64.const -inf", context)
+            .parseNumericConstant(0) ?: fail("Expected an instruction")
+        assertThat(result.parseLength).isEqualTo(2)
+        val instruction = result.astNode as NumericConstantInstruction.F64
+        assertThat(instruction.value.value).isEqualTo(Double.NEGATIVE_INFINITY)
     }
 }

--- a/library/src/test/java/kwasm/format/text/token/FloatLiteralTest.kt
+++ b/library/src/test/java/kwasm/format/text/token/FloatLiteralTest.kt
@@ -33,6 +33,24 @@ class FloatLiteralTest {
     }
 
     @Test
+    fun parsesInf_32() {
+        val actual = FloatLiteral("inf", 32)
+        assertThat(actual.isInfinite()).isTrue()
+    }
+
+    @Test
+    fun parsesNegInf() {
+        val actual = FloatLiteral("-inf")
+        assertThat(actual.isInfinite()).isTrue()
+    }
+
+    @Test
+    fun parsesNegInf_32() {
+        val actual = FloatLiteral("-inf", 32)
+        assertThat(actual.isInfinite()).isTrue()
+    }
+
+    @Test
     fun parsesNaN() {
         val actual = FloatLiteral("nan")
         assertThat(actual.isNaN()).isTrue()
@@ -41,6 +59,18 @@ class FloatLiteralTest {
     @Test
     fun parsesHexNaN() {
         val actual = FloatLiteral("nan:0xF")
+        assertThat(actual.isNaN()).isTrue()
+    }
+
+    @Test
+    fun parsesNaN_32() {
+        val actual = FloatLiteral("nan", 32)
+        assertThat(actual.isNaN()).isTrue()
+    }
+
+    @Test
+    fun parsesHexNaN_32() {
+        val actual = FloatLiteral("nan:0xF", 32)
         assertThat(actual.isNaN()).isTrue()
     }
 
@@ -224,6 +254,18 @@ class FloatLiteralTest {
     @Test
     fun isFloatLiteral_returnsTrue_ifEntireSequenceIsFloat() {
         val input = RawToken("-12345789.01e+34", CONTEXT)
+        assertThat(input.isFloatLiteral()).isTrue()
+    }
+
+    @Test
+    fun isFloatLiteral_returnsTrue_ifEntireSequenceIsFloat_nan() {
+        val input = RawToken("nan", CONTEXT)
+        assertThat(input.isFloatLiteral()).isTrue()
+    }
+
+    @Test
+    fun isFloatLiteral_returnsTrue_ifEntireSequenceIsFloat_inf() {
+        val input = RawToken("inf", CONTEXT)
         assertThat(input.isFloatLiteral()).isTrue()
     }
 


### PR DESCRIPTION
Turns out that inf/nan were being picked up by the Keyword and Reserved word tokenizing steps, but they shouldn't have been.
