### PR TITLE
Allow IntegerLiterals to be used as float values for instructions.

### DIFF
--- a/library/src/main/java/kwasm/format/text/Literal.kt
+++ b/library/src/main/java/kwasm/format/text/Literal.kt
@@ -70,6 +70,10 @@ fun <T : Any> List<Token>.parseLiteral(
         }
         Float::class -> {
             val literalToken = node as? FloatLiteral
+                ?: (node as? IntegerLiteral.Signed)
+                    ?.let { FloatLiteral("${it.value}", context = it.context) }
+                ?: (node as? IntegerLiteral.Unsigned)
+                    ?.let { FloatLiteral("${it.value}", context = it.context) }
                 ?: throw ParseException("Expected f32", context)
             literalToken.magnitude = 32
 
@@ -77,6 +81,10 @@ fun <T : Any> List<Token>.parseLiteral(
         }
         Double::class -> {
             val literalToken = node as? FloatLiteral
+                ?: (node as? IntegerLiteral.Signed)
+                    ?.let { FloatLiteral("${it.value}", context = it.context) }
+                ?: (node as? IntegerLiteral.Unsigned)
+                    ?.let { FloatLiteral("${it.value}", context = it.context) }
                 ?: throw ParseException("Expected f64", context)
             literalToken.magnitude = 64
 

--- a/library/src/test/java/kwasm/format/text/LiteralTest.kt
+++ b/library/src/test/java/kwasm/format/text/LiteralTest.kt
@@ -103,17 +103,29 @@ class LiteralTest {
     }
 
     @Test
-    fun throws_ifLiteral_isNotFloat_whenDesired() {
+    fun ifLiteral_isNotFloat_butIsInt() {
+        val literal = tokenizer.tokenize("1234").parseLiteral(0, Float::class)
+        assertThat(literal.astNode.value).isEqualTo(1234.0f)
+    }
+
+    @Test
+    fun throws_ifLiteral_isNotFloat_isString() {
         val exception = assertThrows(ParseException::class.java) {
-            tokenizer.tokenize("1234").parseLiteral(0, Float::class)
+            tokenizer.tokenize("\"1234\"").parseLiteral(0, Float::class)
         }
         assertThat(exception).hasMessageThat().contains("Expected f32")
     }
 
     @Test
-    fun throws_ifLiteral_isNotDouble_whenDesired() {
+    fun ifLiteral_isNotDouble_butIsInt() {
+        val literal = tokenizer.tokenize("1234").parseLiteral(0, Double::class)
+        assertThat(literal.astNode.value).isEqualTo(1234.0)
+    }
+
+    @Test
+    fun throws_ifLiteral_isNotDouble_isString() {
         val exception = assertThrows(ParseException::class.java) {
-            tokenizer.tokenize("1234").parseLiteral(0, Double::class)
+            tokenizer.tokenize("\"1234\"").parseLiteral(0, Double::class)
         }
         assertThat(exception).hasMessageThat().contains("Expected f64")
     }

--- a/library/src/test/java/kwasm/format/text/instruction/NumericConstantInstructionTest.kt
+++ b/library/src/test/java/kwasm/format/text/instruction/NumericConstantInstructionTest.kt
@@ -83,11 +83,12 @@ class NumericConstantInstructionTest {
     }
 
     @Test
-    fun throws_if_i32Const_followedByInt() {
-        assertThrows(ParseException::class.java) {
-            tokenizer.tokenize("f32.const 1", context)
-                .parseNumericConstant(0)
-        }
+    fun f32Const_followedByInt() {
+        val result = tokenizer.tokenize("f32.const 1", context)
+            .parseNumericConstant(0) ?: fail("Expected an instruction")
+        assertThat(result.parseLength).isEqualTo(2)
+        val instruction = result.astNode as NumericConstantInstruction.F32
+        assertThat(instruction.value.value).isEqualTo(1.0f)
     }
 
     @Test
@@ -127,11 +128,12 @@ class NumericConstantInstructionTest {
     }
 
     @Test
-    fun throws_if_i64Const_followedByInt() {
-        assertThrows(ParseException::class.java) {
-            tokenizer.tokenize("f64.const 1", context)
-                .parseNumericConstant(0)
-        }
+    fun f64Const_followedByInt() {
+        val result = tokenizer.tokenize("f64.const 1", context)
+            .parseNumericConstant(0) ?: fail("Expected an instruction")
+        assertThat(result.parseLength).isEqualTo(2)
+        val instruction = result.astNode as NumericConstantInstruction.F64
+        assertThat(instruction.value.value).isEqualTo(1.0)
     }
 
     @Test


### PR DESCRIPTION
Fixes #247
