### PR TITLE
Overhaul how Identifiers and Indices are parsed.

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -6,6 +6,7 @@
       </option>
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
+      <option name="ALLOW_TRAILING_COMMA" value="true" />
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>
     <codeStyleSettings language="XML">

--- a/library/src/main/java/kwasm/ast/module/Index.kt
+++ b/library/src/main/java/kwasm/ast/module/Index.kt
@@ -39,8 +39,7 @@ import kwasm.ast.Identifier
  *                      v:id    => l (if I.labels[l] = v)
  * ```
  */
-sealed class Index<T : Identifier> :
-    AstNode {
+sealed class Index<T : Identifier> : AstNode {
     data class ByInt(val indexVal: Int) : Index<Identifier>() {
         override fun toString(): String = indexVal.toString()
     }

--- a/library/src/main/java/kwasm/format/text/Counters.kt
+++ b/library/src/main/java/kwasm/format/text/Counters.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kwasm.format.text
+
+import kwasm.ast.Identifier
+
+data class TextModuleCounts(
+    val types: Int,
+    val functions: Int,
+    val tables: Int,
+    val memories: Int,
+    val globals: Int
+)
+
+fun <T : Identifier> TextModuleCounts.incrementFor(
+    identifier: T
+): TextModuleCounts = when (identifier) {
+    is Identifier.Type -> copy(types = types + 1)
+    is Identifier.Function -> copy(functions = functions + 1)
+    is Identifier.Table -> copy(tables = tables + 1)
+    is Identifier.Memory -> copy(memories = memories + 1)
+    is Identifier.Global -> copy(globals = globals + 1)
+    else -> this
+}

--- a/library/src/main/java/kwasm/format/text/module/DataSegment.kt
+++ b/library/src/main/java/kwasm/format/text/module/DataSegment.kt
@@ -19,6 +19,7 @@ import kwasm.ast.module.DataSegment
 import kwasm.ast.module.Index
 import kwasm.format.parseCheck
 import kwasm.format.text.ParseResult
+import kwasm.format.text.TextModuleCounts
 import kwasm.format.text.contextAt
 import kwasm.format.text.isClosedParen
 import kwasm.format.text.isKeyword
@@ -42,7 +43,10 @@ import kwasm.format.text.token.Token
  * symbolic memory identifier resolving to the same value.
  */
 @Suppress("UNCHECKED_CAST", "EXPERIMENTAL_UNSIGNED_LITERALS")
-fun List<Token>.parseDataSegment(fromIndex: Int): ParseResult<DataSegment>? {
+fun List<Token>.parseDataSegment(
+    fromIndex: Int,
+    counts: TextModuleCounts,
+): Pair<ParseResult<DataSegment>, TextModuleCounts>? {
     var currentIndex = fromIndex
     if (!isOpenParen(currentIndex)) return null
     currentIndex++
@@ -76,7 +80,7 @@ fun List<Token>.parseDataSegment(fromIndex: Int): ParseResult<DataSegment>? {
             dataStringBytes
         ),
         currentIndex - fromIndex
-    )
+    ) to counts
 }
 
 internal fun List<Token>.parseDataString(fromIndex: Int): Pair<ByteArray, Int> {

--- a/library/src/main/java/kwasm/format/text/module/ElementSegment.kt
+++ b/library/src/main/java/kwasm/format/text/module/ElementSegment.kt
@@ -19,6 +19,7 @@ import kwasm.ast.module.ElementSegment
 import kwasm.ast.module.Index
 import kwasm.format.parseCheck
 import kwasm.format.text.ParseResult
+import kwasm.format.text.TextModuleCounts
 import kwasm.format.text.contextAt
 import kwasm.format.text.isClosedParen
 import kwasm.format.text.isKeyword
@@ -36,7 +37,10 @@ import kwasm.format.text.token.Token
  * ```
  */
 @Suppress("UNCHECKED_CAST", "EXPERIMENTAL_UNSIGNED_LITERALS")
-fun List<Token>.parseElementSegment(fromIndex: Int): ParseResult<ElementSegment>? {
+fun List<Token>.parseElementSegment(
+    fromIndex: Int,
+    counts: TextModuleCounts,
+): Pair<ParseResult<ElementSegment>, TextModuleCounts>? {
     var currentIndex = fromIndex
     if (!isOpenParen(currentIndex)) return null
     currentIndex++
@@ -69,5 +73,5 @@ fun List<Token>.parseElementSegment(fromIndex: Int): ParseResult<ElementSegment>
             funcIndices.astNode
         ),
         currentIndex - fromIndex
-    )
+    ) to counts
 }

--- a/library/src/main/java/kwasm/format/text/module/Export.kt
+++ b/library/src/main/java/kwasm/format/text/module/Export.kt
@@ -21,6 +21,7 @@ import kwasm.format.ParseException
 import kwasm.format.parseCheck
 import kwasm.format.parseCheckNotNull
 import kwasm.format.text.ParseResult
+import kwasm.format.text.TextModuleCounts
 import kwasm.format.text.contextAt
 import kwasm.format.text.isClosedParen
 import kwasm.format.text.isKeyword
@@ -38,7 +39,10 @@ import kwasm.format.text.token.Token
  *   export_I ::= ‘(’ ‘export’ nm:name d:exportdesc_I ‘)’ => {name nm, desc d}
  * ```
  */
-fun List<Token>.parseExport(fromIndex: Int): ParseResult<Export>? {
+fun List<Token>.parseExport(
+    fromIndex: Int,
+    counts: TextModuleCounts,
+): Pair<ParseResult<Export>, TextModuleCounts>? {
     var currentIndex = fromIndex
     if (!isOpenParen(currentIndex)) return null
     currentIndex++
@@ -56,7 +60,7 @@ fun List<Token>.parseExport(fromIndex: Int): ParseResult<Export>? {
             descriptor.astNode
         ),
         currentIndex - fromIndex
-    )
+    ) to counts
 }
 
 /**

--- a/library/src/main/java/kwasm/format/text/module/Global.kt
+++ b/library/src/main/java/kwasm/format/text/module/Global.kt
@@ -32,7 +32,6 @@ import kwasm.format.text.instruction.parseExpression
 import kwasm.format.text.isClosedParen
 import kwasm.format.text.isKeyword
 import kwasm.format.text.isOpenParen
-import kwasm.format.text.parseIdentifier
 import kwasm.format.text.parseLiteral
 import kwasm.format.text.parseOrCreateIdentifier
 import kwasm.format.text.token.Token

--- a/library/src/main/java/kwasm/format/text/module/Global.kt
+++ b/library/src/main/java/kwasm/format/text/module/Global.kt
@@ -26,6 +26,7 @@ import kwasm.ast.module.Index
 import kwasm.format.parseCheck
 import kwasm.format.parseCheckNotNull
 import kwasm.format.text.ParseResult
+import kwasm.format.text.TextModuleCounts
 import kwasm.format.text.contextAt
 import kwasm.format.text.instruction.parseExpression
 import kwasm.format.text.isClosedParen
@@ -33,6 +34,7 @@ import kwasm.format.text.isKeyword
 import kwasm.format.text.isOpenParen
 import kwasm.format.text.parseIdentifier
 import kwasm.format.text.parseLiteral
+import kwasm.format.text.parseOrCreateIdentifier
 import kwasm.format.text.token.Token
 import kwasm.format.text.tokensUntilParenClosure
 import kwasm.format.text.type.parseGlobalType
@@ -46,14 +48,17 @@ import kwasm.format.text.type.parseGlobalType
  *   global_I   ::= ‘(’ ‘global’ id? gt:globaltype  e:expr_I ‘)’    => {type gt, init e}
  * ```
  */
-fun List<Token>.parseGlobal(fromIndex: Int): ParseResult<Global>? {
+fun List<Token>.parseGlobal(
+    fromIndex: Int,
+    counts: TextModuleCounts,
+): Pair<ParseResult<Global>, TextModuleCounts>? {
     var currentIndex = fromIndex
     if (!isOpenParen(currentIndex)) return null
     currentIndex++
     if (!isKeyword(currentIndex, "global")) return null
     currentIndex++
 
-    val id = parseIdentifier<Identifier.Global>(currentIndex)
+    val (id, updatedCounts) = parseOrCreateIdentifier<Identifier.Global>(currentIndex, counts)
     currentIndex += id.parseLength
 
     val globalType = parseGlobalType(currentIndex)
@@ -72,7 +77,7 @@ fun List<Token>.parseGlobal(fromIndex: Int): ParseResult<Global>? {
             expression.astNode
         ),
         currentIndex - fromIndex
-    )
+    ) to updatedCounts
 }
 
 /**
@@ -85,15 +90,18 @@ fun List<Token>.parseGlobal(fromIndex: Int): ParseResult<Global>? {
  *      == ‘(’ ‘import’ name^1 name^2 ‘(’ ‘global’ id? globaltype ‘)’ ‘)’
  * ```
  */
-fun List<Token>.parseInlineGlobalImport(fromIndex: Int): ParseResult<Import>? {
+fun List<Token>.parseInlineGlobalImport(
+    fromIndex: Int,
+    counts: TextModuleCounts,
+): Pair<ParseResult<Import>, TextModuleCounts>? {
     var currentIndex = fromIndex
     if (!isOpenParen(currentIndex)) return null
     currentIndex++
     if (!isKeyword(currentIndex, "global")) return null
     currentIndex++
 
-    val identifier = parseIdentifier<Identifier.Global>(currentIndex)
-    currentIndex += identifier.parseLength
+    val (id, updatedCounts) = parseOrCreateIdentifier<Identifier.Global>(currentIndex, counts)
+    currentIndex += id.parseLength
 
     if (!isOpenParen(currentIndex)) return null
     currentIndex++
@@ -119,12 +127,12 @@ fun List<Token>.parseInlineGlobalImport(fromIndex: Int): ParseResult<Import>? {
             moduleName.astNode.value,
             tableName.astNode.value,
             ImportDescriptor.Global(
-                identifier.astNode,
+                id.astNode,
                 globalType.astNode
             )
         ),
         currentIndex - fromIndex
-    )
+    ) to updatedCounts
 }
 
 /**
@@ -140,15 +148,19 @@ fun List<Token>.parseInlineGlobalImport(fromIndex: Int): ParseResult<Import>? {
  *
  * Where “...” can contain another import or export.
  */
-fun List<Token>.parseInlineGlobalExport(fromIndex: Int): ParseResult<AstNodeList<*>>? {
+@Suppress("UNCHECKED_CAST")
+fun List<Token>.parseInlineGlobalExport(
+    fromIndex: Int,
+    counts: TextModuleCounts,
+): Pair<ParseResult<AstNodeList<AstNode>>, TextModuleCounts>? {
     var currentIndex = fromIndex
     if (!isOpenParen(currentIndex)) return null
     currentIndex++
     if (!isKeyword(currentIndex, "global")) return null
     currentIndex++
 
-    val identifier = parseIdentifier<Identifier.Global>(currentIndex)
-    currentIndex += identifier.parseLength
+    val (id, updatedCounts) = parseOrCreateIdentifier<Identifier.Global>(currentIndex, counts)
+    currentIndex += id.parseLength
 
     if (!isOpenParen(currentIndex)) return null
     currentIndex++
@@ -165,9 +177,7 @@ fun List<Token>.parseInlineGlobalExport(fromIndex: Int): ParseResult<AstNodeList
         Export(
             exportName.astNode.value,
             ExportDescriptor.Global(
-                Index.ByIdentifier(
-                    identifier.astNode
-                )
+                Index.ByInt(updatedCounts.globals - 1) as Index<Identifier.Global>
             )
         )
     )
@@ -178,7 +188,7 @@ fun List<Token>.parseInlineGlobalExport(fromIndex: Int): ParseResult<AstNodeList
         return ParseResult(
             AstNodeList(result),
             currentIndex - fromIndex
-        )
+        ) to updatedCounts
     }
 
     // Looks like there might be more to handle, so construct a new list of tokens to recurse with.
@@ -189,10 +199,8 @@ fun List<Token>.parseInlineGlobalExport(fromIndex: Int): ParseResult<AstNodeList
     )
 
     // Add the id.
-    if (identifier.parseLength == 0) {
-        withoutFirstExport.add(kwasm.format.text.token.Identifier(identifier.astNode.toString()))
-    } else {
-        (0 until identifier.parseLength).forEach {
+    if (id.parseLength > 0) {
+        (0 until id.parseLength).forEach {
             withoutFirstExport.add(this[fromIndex + 2 + it])
         }
     }
@@ -203,11 +211,11 @@ fun List<Token>.parseInlineGlobalExport(fromIndex: Int): ParseResult<AstNodeList
     withoutFirstExport.addAll(tokensUntilParenClosure(currentIndex, expectedClosures = 1))
 
     // Recurse.
-    val additionalItems = parseCheckNotNull(
+    val (additionalItems, _) = parseCheckNotNull(
         contextAt(currentIndex),
-        withoutFirstExport.parseInlineGlobalExport(0)
-            ?: withoutFirstExport.parseInlineGlobalImport(0)
-            ?: withoutFirstExport.parseGlobal(0),
+        withoutFirstExport.parseInlineGlobalExport(0, counts)
+            ?: withoutFirstExport.parseInlineGlobalImport(0, counts)
+            ?: withoutFirstExport.parseGlobal(0, counts),
         "Expected additional details for global"
     )
     currentIndex += (additionalItems.parseLength - lengthOfPrefix)
@@ -220,5 +228,5 @@ fun List<Token>.parseInlineGlobalExport(fromIndex: Int): ParseResult<AstNodeList
     return ParseResult(
         AstNodeList(result),
         currentIndex - fromIndex
-    )
+    ) to updatedCounts
 }

--- a/library/src/main/java/kwasm/format/text/module/Import.kt
+++ b/library/src/main/java/kwasm/format/text/module/Import.kt
@@ -20,12 +20,14 @@ import kwasm.ast.module.ImportDescriptor
 import kwasm.format.parseCheck
 import kwasm.format.parseCheckNotNull
 import kwasm.format.text.ParseResult
+import kwasm.format.text.TextModuleCounts
 import kwasm.format.text.contextAt
 import kwasm.format.text.isClosedParen
 import kwasm.format.text.isKeyword
 import kwasm.format.text.isOpenParen
 import kwasm.format.text.parseIdentifier
 import kwasm.format.text.parseLiteral
+import kwasm.format.text.parseOrCreateIdentifier
 import kwasm.format.text.token.Token
 import kwasm.format.text.type.parseGlobalType
 import kwasm.format.text.type.parseMemoryType
@@ -40,7 +42,10 @@ import kwasm.format.text.type.parseTableType
  *   import_I ::= ‘(’ ‘import’ mod:name nm:name d:importdesc_I ‘)’ => {module mod, name nm, desc d}
  * ```
  */
-fun List<Token>.parseImport(fromIndex: Int): ParseResult<Import>? {
+fun List<Token>.parseImport(
+    fromIndex: Int,
+    counts: TextModuleCounts
+): Pair<ParseResult<Import>, TextModuleCounts>? {
     var currentIndex = fromIndex
     if (!isOpenParen(currentIndex)) return null
     currentIndex++
@@ -50,9 +55,9 @@ fun List<Token>.parseImport(fromIndex: Int): ParseResult<Import>? {
     currentIndex += moduleName.parseLength
     val name = parseLiteral(currentIndex, String::class)
     currentIndex += moduleName.parseLength
-    val importDescriptor = parseCheckNotNull(
+    val (importDescriptor, updatedCounts) = parseCheckNotNull(
         contextAt(currentIndex),
-        parseImportDescriptor(currentIndex),
+        parseImportDescriptor(currentIndex, counts),
         "Expected import descriptor"
     )
     currentIndex += importDescriptor.parseLength
@@ -65,7 +70,7 @@ fun List<Token>.parseImport(fromIndex: Int): ParseResult<Import>? {
             importDescriptor.astNode
         ),
         currentIndex - fromIndex
-    )
+    ) to updatedCounts
 }
 
 /**
@@ -81,21 +86,26 @@ fun List<Token>.parseImport(fromIndex: Int): ParseResult<Import>? {
  * ```
  */
 @Suppress("UNCHECKED_CAST")
-fun List<Token>.parseImportDescriptor(fromIndex: Int): ParseResult<out ImportDescriptor>? =
-    parseFuncImportDescriptor(fromIndex)
-        ?: parseTableImportDescriptor(fromIndex)
-        ?: parseMemoryImportDescriptor(fromIndex)
-        ?: parseGlobalImportDescriptor(fromIndex)
+fun List<Token>.parseImportDescriptor(
+    fromIndex: Int,
+    counts: TextModuleCounts
+): Pair<ParseResult<out ImportDescriptor>, TextModuleCounts>? {
+    return parseFuncImportDescriptor(fromIndex, counts)
+        ?: parseTableImportDescriptor(fromIndex, counts)
+        ?: parseMemoryImportDescriptor(fromIndex, counts)
+        ?: parseGlobalImportDescriptor(fromIndex, counts)
+}
 
 internal fun List<Token>.parseFuncImportDescriptor(
-    fromIndex: Int
-): ParseResult<ImportDescriptor.Function>? {
+    fromIndex: Int,
+    counts: TextModuleCounts
+): Pair<ParseResult<ImportDescriptor.Function>, TextModuleCounts>? {
     var currentIndex = fromIndex
     if (!isOpenParen(currentIndex)) return null
     currentIndex++
     if (!isKeyword(currentIndex, "func")) return null
     currentIndex++
-    val id = parseIdentifier<Identifier.Function>(currentIndex)
+    val (id, updatedCounts) = parseOrCreateIdentifier<Identifier.Function>(currentIndex, counts)
     currentIndex += id.parseLength
     val typeUse = parseTypeUse(currentIndex)
     currentIndex += typeUse.parseLength
@@ -104,18 +114,19 @@ internal fun List<Token>.parseFuncImportDescriptor(
     return ParseResult(
         ImportDescriptor.Function(id.astNode, typeUse.astNode),
         currentIndex - fromIndex
-    )
+    ) to updatedCounts
 }
 
 internal fun List<Token>.parseTableImportDescriptor(
-    fromIndex: Int
-): ParseResult<ImportDescriptor.Table>? {
+    fromIndex: Int,
+    counts: TextModuleCounts
+): Pair<ParseResult<ImportDescriptor.Table>, TextModuleCounts>? {
     var currentIndex = fromIndex
     if (!isOpenParen(currentIndex)) return null
     currentIndex++
     if (!isKeyword(currentIndex, "table")) return null
     currentIndex++
-    val id = parseIdentifier<Identifier.Table>(currentIndex)
+    val (id, updatedCounts) = parseOrCreateIdentifier<Identifier.Table>(currentIndex, counts)
     currentIndex += id.parseLength
     val tableType = parseTableType(currentIndex)
     currentIndex += tableType.parseLength
@@ -124,18 +135,19 @@ internal fun List<Token>.parseTableImportDescriptor(
     return ParseResult(
         ImportDescriptor.Table(id.astNode, tableType.astNode),
         currentIndex - fromIndex
-    )
+    ) to updatedCounts
 }
 
 internal fun List<Token>.parseMemoryImportDescriptor(
-    fromIndex: Int
-): ParseResult<ImportDescriptor.Memory>? {
+    fromIndex: Int,
+    counts: TextModuleCounts
+): Pair<ParseResult<ImportDescriptor.Memory>, TextModuleCounts>? {
     var currentIndex = fromIndex
     if (!isOpenParen(currentIndex)) return null
     currentIndex++
     if (!isKeyword(currentIndex, "memory")) return null
     currentIndex++
-    val id = parseIdentifier<Identifier.Memory>(currentIndex)
+    val (id, updatedCounts) = parseOrCreateIdentifier<Identifier.Memory>(currentIndex, counts)
     currentIndex += id.parseLength
     val memoryType = parseMemoryType(currentIndex)
     currentIndex += memoryType.parseLength
@@ -144,16 +156,19 @@ internal fun List<Token>.parseMemoryImportDescriptor(
     return ParseResult(
         ImportDescriptor.Memory(id.astNode, memoryType.astNode),
         currentIndex - fromIndex
-    )
+    ) to updatedCounts
 }
 
-internal fun List<Token>.parseGlobalImportDescriptor(fromIndex: Int): ParseResult<ImportDescriptor.Global>? {
+internal fun List<Token>.parseGlobalImportDescriptor(
+    fromIndex: Int,
+    counts: TextModuleCounts
+): Pair<ParseResult<ImportDescriptor.Global>, TextModuleCounts>? {
     var currentIndex = fromIndex
     if (!isOpenParen(currentIndex)) return null
     currentIndex++
     if (!isKeyword(currentIndex, "global")) return null
     currentIndex++
-    val id = parseIdentifier<Identifier.Global>(currentIndex)
+    val (id, updatedCounts) = parseOrCreateIdentifier<Identifier.Global>(currentIndex, counts)
     currentIndex += id.parseLength
     val globalType = parseGlobalType(currentIndex)
     currentIndex += globalType.parseLength
@@ -162,5 +177,5 @@ internal fun List<Token>.parseGlobalImportDescriptor(fromIndex: Int): ParseResul
     return ParseResult(
         ImportDescriptor.Global(id.astNode, globalType.astNode),
         currentIndex - fromIndex
-    )
+    ) to updatedCounts
 }

--- a/library/src/main/java/kwasm/format/text/module/Import.kt
+++ b/library/src/main/java/kwasm/format/text/module/Import.kt
@@ -25,7 +25,6 @@ import kwasm.format.text.contextAt
 import kwasm.format.text.isClosedParen
 import kwasm.format.text.isKeyword
 import kwasm.format.text.isOpenParen
-import kwasm.format.text.parseIdentifier
 import kwasm.format.text.parseLiteral
 import kwasm.format.text.parseOrCreateIdentifier
 import kwasm.format.text.token.Token

--- a/library/src/main/java/kwasm/format/text/module/Memory.kt
+++ b/library/src/main/java/kwasm/format/text/module/Memory.kt
@@ -40,7 +40,6 @@ import kwasm.format.text.contextAt
 import kwasm.format.text.isClosedParen
 import kwasm.format.text.isKeyword
 import kwasm.format.text.isOpenParen
-import kwasm.format.text.parseIdentifier
 import kwasm.format.text.parseLiteral
 import kwasm.format.text.parseOrCreateIdentifier
 import kwasm.format.text.token.Token

--- a/library/src/main/java/kwasm/format/text/module/StartFunction.kt
+++ b/library/src/main/java/kwasm/format/text/module/StartFunction.kt
@@ -18,6 +18,7 @@ import kwasm.ast.Identifier
 import kwasm.ast.module.StartFunction
 import kwasm.format.parseCheck
 import kwasm.format.text.ParseResult
+import kwasm.format.text.TextModuleCounts
 import kwasm.format.text.contextAt
 import kwasm.format.text.isClosedParen
 import kwasm.format.text.isKeyword
@@ -35,7 +36,10 @@ import kwasm.format.text.token.Token
  *   start_I ::= ‘(’ ‘start’ x:funcidx_I ‘)’ => {func x}
  * ```
  */
-fun List<Token>.parseStartFunction(fromIndex: Int): ParseResult<StartFunction>? {
+fun List<Token>.parseStartFunction(
+    fromIndex: Int,
+    counts: TextModuleCounts,
+): Pair<ParseResult<StartFunction>, TextModuleCounts>? {
     var currentIndex = fromIndex
     if (!isOpenParen(fromIndex)) return null
     currentIndex++
@@ -52,5 +56,5 @@ fun List<Token>.parseStartFunction(fromIndex: Int): ParseResult<StartFunction>? 
     return ParseResult(
         StartFunction(funcIndex.astNode),
         currentIndex - fromIndex
-    )
+    ) to counts
 }

--- a/library/src/main/java/kwasm/format/text/module/Table.kt
+++ b/library/src/main/java/kwasm/format/text/module/Table.kt
@@ -41,7 +41,6 @@ import kwasm.format.text.contextAt
 import kwasm.format.text.isClosedParen
 import kwasm.format.text.isKeyword
 import kwasm.format.text.isOpenParen
-import kwasm.format.text.parseIdentifier
 import kwasm.format.text.parseLiteral
 import kwasm.format.text.parseOrCreateIdentifier
 import kwasm.format.text.token.Keyword

--- a/library/src/main/java/kwasm/format/text/module/Type.kt
+++ b/library/src/main/java/kwasm/format/text/module/Type.kt
@@ -18,8 +18,10 @@ import kwasm.ast.module.Type
 import kwasm.ast.type.FunctionType
 import kwasm.format.parseCheck
 import kwasm.format.text.ParseResult
+import kwasm.format.text.TextModuleCounts
 import kwasm.format.text.asKeywordMatching
 import kwasm.format.text.contextAt
+import kwasm.format.text.incrementFor
 import kwasm.format.text.isClosedParen
 import kwasm.format.text.isOpenParen
 import kwasm.format.text.token.Identifier
@@ -35,7 +37,10 @@ import kwasm.format.text.type.parseFunctionType
  *   type ::= ‘(’ ‘type’ id? ft:functype ‘)’ => ft
  * ```
  */
-fun List<Token>.parseType(fromIndex: Int): ParseResult<Type>? {
+fun List<Token>.parseType(
+    fromIndex: Int,
+    counts: TextModuleCounts,
+): Pair<ParseResult<Type>, TextModuleCounts>? {
     var currentIndex = fromIndex
     if (!isOpenParen(currentIndex)) return null
     currentIndex++
@@ -57,5 +62,5 @@ fun List<Token>.parseType(fromIndex: Int): ParseResult<Type>? {
     return ParseResult(
         Type(astTypeIdentifier, funcType.astNode),
         currentIndex - fromIndex
-    )
+    ) to counts.copy(types = counts.types + 1)
 }

--- a/library/src/main/java/kwasm/format/text/module/Type.kt
+++ b/library/src/main/java/kwasm/format/text/module/Type.kt
@@ -21,7 +21,6 @@ import kwasm.format.text.ParseResult
 import kwasm.format.text.TextModuleCounts
 import kwasm.format.text.asKeywordMatching
 import kwasm.format.text.contextAt
-import kwasm.format.text.incrementFor
 import kwasm.format.text.isClosedParen
 import kwasm.format.text.isOpenParen
 import kwasm.format.text.token.Identifier

--- a/library/src/main/java/kwasm/format/text/module/WasmFunction.kt
+++ b/library/src/main/java/kwasm/format/text/module/WasmFunction.kt
@@ -32,7 +32,6 @@ import kwasm.format.text.instruction.parseInstructions
 import kwasm.format.text.isClosedParen
 import kwasm.format.text.isKeyword
 import kwasm.format.text.isOpenParen
-import kwasm.format.text.parseIdentifier
 import kwasm.format.text.parseLiteral
 import kwasm.format.text.parseOrCreateIdentifier
 import kwasm.format.text.token.Token

--- a/library/src/main/java/kwasm/format/text/module/WasmModule.kt
+++ b/library/src/main/java/kwasm/format/text/module/WasmModule.kt
@@ -29,6 +29,7 @@ import kwasm.ast.module.WasmFunction
 import kwasm.ast.module.WasmModule
 import kwasm.format.parseCheck
 import kwasm.format.text.ParseResult
+import kwasm.format.text.TextModuleCounts
 import kwasm.format.text.contextAt
 import kwasm.format.text.instruction.parseLabel
 import kwasm.format.text.isClosedParen
@@ -73,31 +74,33 @@ fun List<Token>.parseModule(fromIndex: Int): ParseResult<WasmModule>? {
 
     val allNodes = mutableListOf<AstNode>()
 
+    var counts = TextModuleCounts(0, 0, 0, 0, 0)
     while (true) {
-        val parseResult = parseType(currentIndex)
-            ?: parseImport(currentIndex)
-            ?: parseInlineWasmFunctionImport(currentIndex)
-            ?: parseInlineWasmFunctionExport(currentIndex)
-            ?: parseWasmFunction(currentIndex)
-            ?: parseInlineTableImport(currentIndex)
-            ?: parseInlineTableExport(currentIndex)
-            ?: parseTable(currentIndex)
-            ?: parseInlineMemoryImport(currentIndex)
-            ?: parseInlineMemoryExport(currentIndex)
-            ?: parseMemory(currentIndex)
-            ?: parseInlineGlobalImport(currentIndex)
-            ?: parseInlineGlobalExport(currentIndex)
-            ?: parseGlobal(currentIndex)
-            ?: parseExport(currentIndex)
-            ?: parseStartFunction(currentIndex)
-            ?: parseElementSegment(currentIndex)
-            ?: parseDataSegment(currentIndex)
+        val (parseResult, updatedCounts) = parseType(currentIndex, counts)
+            ?: parseImport(currentIndex, counts)
+            ?: parseInlineWasmFunctionImport(currentIndex, counts)
+            ?: parseInlineWasmFunctionExport(currentIndex, counts)
+            ?: parseWasmFunction(currentIndex, counts)
+            ?: parseInlineTableImport(currentIndex, counts)
+            ?: parseInlineTableExport(currentIndex, counts)
+            ?: parseTable(currentIndex, counts)
+            ?: parseInlineMemoryImport(currentIndex, counts)
+            ?: parseInlineMemoryExport(currentIndex, counts)
+            ?: parseMemory(currentIndex, counts)
+            ?: parseInlineGlobalImport(currentIndex, counts)
+            ?: parseInlineGlobalExport(currentIndex, counts)
+            ?: parseGlobal(currentIndex, counts)
+            ?: parseExport(currentIndex, counts)
+            ?: parseStartFunction(currentIndex, counts)
+            ?: parseElementSegment(currentIndex, counts)
+            ?: parseDataSegment(currentIndex, counts)
             ?: break
         when (val node = parseResult.astNode) {
             is AstNodeList<*> -> allNodes.addAll(node)
             else -> allNodes.add(node)
         }
         currentIndex += parseResult.parseLength
+        counts = updatedCounts
     }
 
     parseCheck(contextAt(currentIndex), isClosedParen(currentIndex), "Expected ')'")

--- a/library/src/main/java/kwasm/format/text/type/Param.kt
+++ b/library/src/main/java/kwasm/format/text/type/Param.kt
@@ -41,7 +41,7 @@ fun List<Token>.parseParam(fromIndex: Int): ParseResult<AstNodeList<Param>> {
     parseCheck(contextAt(currentIndex), isKeyword(currentIndex, "param"), "Invalid Param: Expecting \"param\"")
     currentIndex++
     val id = parseIdentifier<Identifier.Local>(currentIndex)
-    currentIndex += id.parseLength
+    currentIndex += id?.parseLength ?: 0
     val valueTypes = parseValueTypes(currentIndex, minRequired = 1)
     currentIndex += valueTypes.parseLength
     parseCheck(contextAt(currentIndex), isClosedParen(currentIndex), "Invalid Param: Expecting ) token")
@@ -50,7 +50,7 @@ fun List<Token>.parseParam(fromIndex: Int): ParseResult<AstNodeList<Param>> {
         AstNodeList(
             valueTypes.astNode.map {
                 Param(
-                    id.astNode,
+                    id?.astNode ?: Identifier.Local(null, null),
                     it
                 )
             }

--- a/library/src/main/java/kwasm/runtime/instruction/MemoryInstruction.kt
+++ b/library/src/main/java/kwasm/runtime/instruction/MemoryInstruction.kt
@@ -119,7 +119,7 @@ internal fun MemoryInstruction.LoadFloat.execute(context: ExecutionContext): Exe
                 throw KWasmRuntimeException("Illegal byte width: $byteWidth for load instruction")
         }
     } catch (e: IndexOutOfBoundsException) {
-        throw KWasmRuntimeException("Cannot load at position $ea", e)
+        throw KWasmRuntimeException("Cannot load at position $ea (out of bounds memory access)", e)
     }
     context.stacks.operands.push(resultValue)
     return context

--- a/library/src/main/java/kwasm/runtime/instruction/NumericInstruction.kt
+++ b/library/src/main/java/kwasm/runtime/instruction/NumericInstruction.kt
@@ -625,9 +625,9 @@ internal fun NumericInstruction.execute(context: ExecutionContext): ExecutionCon
         }
         NumericInstruction.I64TruncateF32Signed -> unaryOp<FloatValue, LongValue>(context) { x ->
             if (x.value.isNaN())
-                throw KWasmRuntimeException("Cannot truncate NaN")
+                throw KWasmRuntimeException(EXCEPTION_TRUNCATE_NAN)
             if (x.value.isInfinite())
-                throw KWasmRuntimeException("Cannot truncate Infinity")
+                throw KWasmRuntimeException(EXCEPTION_TRUNCATE_INF)
             val truncated = truncate(x.value)
             if (truncated > Long.MAX_VALUE || truncated < Long.MIN_VALUE)
                 throw KWasmRuntimeException("Cannot truncate, magnitude too large for i64")
@@ -638,9 +638,9 @@ internal fun NumericInstruction.execute(context: ExecutionContext): ExecutionCon
         }
         NumericInstruction.I64TruncateF32Unsigned -> unaryOp<FloatValue, LongValue>(context) { x ->
             if (x.value.isNaN())
-                throw KWasmRuntimeException("Cannot truncate NaN")
+                throw KWasmRuntimeException(EXCEPTION_TRUNCATE_NAN)
             if (x.value.isInfinite())
-                throw KWasmRuntimeException("Cannot truncate Infinity")
+                throw KWasmRuntimeException(EXCEPTION_TRUNCATE_INF)
             val truncated = truncate(x.value)
             if (truncated < 0)
                 throw KWasmRuntimeException("Cannot truncate negative f32 to unsigned i64")
@@ -653,9 +653,9 @@ internal fun NumericInstruction.execute(context: ExecutionContext): ExecutionCon
         }
         NumericInstruction.I64TruncateF64Signed -> unaryOp<DoubleValue, LongValue>(context) { x ->
             if (x.value.isNaN())
-                throw KWasmRuntimeException("Cannot truncate NaN")
+                throw KWasmRuntimeException(EXCEPTION_TRUNCATE_NAN)
             if (x.value.isInfinite())
-                throw KWasmRuntimeException("Cannot truncate Infinity")
+                throw KWasmRuntimeException(EXCEPTION_TRUNCATE_INF)
             val truncated = truncate(x.value)
             if (truncated > Long.MAX_VALUE || truncated < Long.MIN_VALUE)
                 throw KWasmRuntimeException("Cannot truncate, magnitude too large for i64")
@@ -666,9 +666,9 @@ internal fun NumericInstruction.execute(context: ExecutionContext): ExecutionCon
         }
         NumericInstruction.I64TruncateF64Unsigned -> unaryOp<DoubleValue, LongValue>(context) { x ->
             if (x.value.isNaN())
-                throw KWasmRuntimeException("Cannot truncate NaN")
+                throw KWasmRuntimeException(EXCEPTION_TRUNCATE_NAN)
             if (x.value.isInfinite())
-                throw KWasmRuntimeException("Cannot truncate Infinity")
+                throw KWasmRuntimeException(EXCEPTION_TRUNCATE_INF)
             val truncated = truncate(x.value)
             if (truncated < 0)
                 throw KWasmRuntimeException("Cannot truncate negative f64 to unsigned i64")

--- a/library/src/test/java/kwasm/ParseRule.kt
+++ b/library/src/test/java/kwasm/ParseRule.kt
@@ -40,7 +40,7 @@ import org.junit.runners.model.Statement
  */
 class ParseRule : TestRule {
     val tokenizer = Tokenizer()
-    private val counts = TextModuleCounts( 0, 0, 0, 0, 0)
+    private val counts = TextModuleCounts(0, 0, 0, 0, 0)
     lateinit var context: ParseContext
 
     override fun apply(base: Statement, description: Description): Statement {

--- a/library/src/test/java/kwasm/ParseRule.kt
+++ b/library/src/test/java/kwasm/ParseRule.kt
@@ -21,6 +21,7 @@ import kwasm.ast.module.Global
 import kwasm.ast.module.Local
 import kwasm.ast.module.WasmModule
 import kwasm.format.ParseContext
+import kwasm.format.text.TextModuleCounts
 import kwasm.format.text.Tokenizer
 import kwasm.format.text.instruction.parseExpression
 import kwasm.format.text.instruction.parseInstruction
@@ -39,6 +40,7 @@ import org.junit.runners.model.Statement
  */
 class ParseRule : TestRule {
     val tokenizer = Tokenizer()
+    private val counts = TextModuleCounts( 0, 0, 0, 0, 0)
     lateinit var context: ParseContext
 
     override fun apply(base: Statement, description: Description): Statement {
@@ -92,7 +94,7 @@ class ParseRule : TestRule {
 
     /** Parse a [Global] from the given wasm source. */
     fun String.parseGlobal(): Global =
-        requireNotNull(tokenize().parseGlobal(0)?.astNode) {
+        requireNotNull(tokenize().parseGlobal(0, counts)?.first?.astNode) {
             "No global found in source:\n$this"
         }
 

--- a/library/src/test/java/kwasm/format/text/module/MemoryInlineImportTest.kt
+++ b/library/src/test/java/kwasm/format/text/module/MemoryInlineImportTest.kt
@@ -22,6 +22,7 @@ import kwasm.ast.type.Limits
 import kwasm.ast.type.MemoryType
 import kwasm.format.ParseContext
 import kwasm.format.ParseException
+import kwasm.format.text.TextModuleCounts
 import kwasm.format.text.Tokenizer
 import org.assertj.core.api.Assertions
 import org.junit.Assert.assertThrows
@@ -32,34 +33,35 @@ import org.junit.runners.JUnit4
 @Suppress("EXPERIMENTAL_API_USAGE", "EXPERIMENTAL_UNSIGNED_LITERALS")
 @RunWith(JUnit4::class)
 class MemoryInlineImportTest {
+    private val counts = TextModuleCounts(0, 0, 0, 0, 0)
     private val tokenizer = Tokenizer()
     private val context = ParseContext("MemoryInlineImportTest.wat")
 
     @Test
     fun parse_returnsNullIf_openingParenNotFound() {
         val result = tokenizer.tokenize("memory $0 (import \"a\" \"b\") 0 1)", context)
-            .parseInlineMemoryImport(0)
+            .parseInlineMemoryImport(0, counts)
         assertThat(result).isNull()
     }
 
     @Test
     fun parse_returnsNullIf_memoryKeywordNotFound() {
         val result = tokenizer.tokenize("(nonmemory $0 (import \"a\" \"b\") 0 1)", context)
-            .parseInlineMemoryImport(0)
+            .parseInlineMemoryImport(0, counts)
         assertThat(result).isNull()
     }
 
     @Test
     fun parse_returnsNullIf_importOpeningParenNotFound() {
         val result = tokenizer.tokenize("(memory $0 import \"a\" \"b\") 0 1)", context)
-            .parseInlineMemoryImport(0)
+            .parseInlineMemoryImport(0, counts)
         assertThat(result).isNull()
     }
 
     @Test
     fun parse_returnsNullIf_importKeywordNotFound() {
         val result = tokenizer.tokenize("(memory $0 (nonimport \"a\" \"b\") 0 1)", context)
-            .parseInlineMemoryImport(0)
+            .parseInlineMemoryImport(0, counts)
         assertThat(result).isNull()
     }
 
@@ -67,7 +69,7 @@ class MemoryInlineImportTest {
     fun parse_throwsIf_moduleNameNotFound() {
         assertThrows(ParseException::class.java) {
             tokenizer.tokenize("(memory $0 (import) 0 1)", context)
-                .parseInlineMemoryImport(0)
+                .parseInlineMemoryImport(0, counts)
         }
     }
 
@@ -75,7 +77,7 @@ class MemoryInlineImportTest {
     fun parse_throwsIf_memoryNameNotFound() {
         assertThrows(ParseException::class.java) {
             tokenizer.tokenize("(memory $0 (import \"a\") 0 1)", context)
-                .parseInlineMemoryImport(0)
+                .parseInlineMemoryImport(0, counts)
         }
     }
 
@@ -83,7 +85,7 @@ class MemoryInlineImportTest {
     fun parse_throwsIf_importNotClosed() {
         val e = assertThrows(ParseException::class.java) {
             tokenizer.tokenize("(memory $0 (import \"a\" \"b\" 0 1)", context)
-                .parseInlineMemoryImport(0)
+                .parseInlineMemoryImport(0, counts)
         }
         assertThat(e).hasMessageThat().contains("Expected ')'")
     }
@@ -92,30 +94,30 @@ class MemoryInlineImportTest {
     fun parse_throwsIf_notClosed() {
         val e = assertThrows(ParseException::class.java) {
             tokenizer.tokenize("(memory $0 (import \"a\" \"b\") 0 1", context)
-                .parseInlineMemoryImport(0)
+                .parseInlineMemoryImport(0, counts)
         }
         assertThat(e).hasMessageThat().contains("Expected ')'")
     }
 
     @Test
     fun parse_minimal() {
-        val result = tokenizer.tokenize("(memory (import \"a\" \"b\") 1)", context)
-            .parseInlineMemoryImport(0)
-            ?: Assertions.fail("Expected a result")
+        val (result, newCounts) = tokenizer.tokenize("(memory (import \"a\" \"b\") 1)", context)
+            .parseInlineMemoryImport(0, counts) ?: Assertions.fail("Expected a result")
 
         assertThat(result.parseLength).isEqualTo(9)
         assertThat(result.astNode.moduleName).isEqualTo("a")
         assertThat(result.astNode.name).isEqualTo("b")
         val descriptor = result.astNode.descriptor as ImportDescriptor.Memory
         assertThat(descriptor.memoryType).isEqualTo(MemoryType(Limits(1)))
+        assertThat(newCounts.memories).isEqualTo(counts.memories + 1)
     }
 
     @Test
     fun parse() {
-        val result = tokenizer.tokenize(
+        val (result, newCounts) = tokenizer.tokenize(
             "(memory $0 (import \"a\" \"b\") 0 1)",
             context
-        ).parseInlineMemoryImport(0) ?: Assertions.fail("Expected a result")
+        ).parseInlineMemoryImport(0, counts) ?: Assertions.fail("Expected a result")
 
         assertThat(result.parseLength).isEqualTo(11)
         assertThat(result.astNode).isEqualTo(
@@ -130,5 +132,6 @@ class MemoryInlineImportTest {
                 )
             )
         )
+        assertThat(newCounts.memories).isEqualTo(counts.memories + 1)
     }
 }

--- a/library/src/test/java/kwasm/format/text/module/StartFunctionTest.kt
+++ b/library/src/test/java/kwasm/format/text/module/StartFunctionTest.kt
@@ -18,7 +18,6 @@ import com.google.common.truth.Truth.assertThat
 import kwasm.ast.Identifier
 import kwasm.ast.module.Index
 import kwasm.ast.module.StartFunction
-import kwasm.format.ParseContext
 import kwasm.format.ParseException
 import kwasm.format.text.TextModuleCounts
 import kwasm.format.text.Tokenizer

--- a/library/src/test/java/kwasm/format/text/module/StartFunctionTest.kt
+++ b/library/src/test/java/kwasm/format/text/module/StartFunctionTest.kt
@@ -20,6 +20,7 @@ import kwasm.ast.module.Index
 import kwasm.ast.module.StartFunction
 import kwasm.format.ParseContext
 import kwasm.format.ParseException
+import kwasm.format.text.TextModuleCounts
 import kwasm.format.text.Tokenizer
 import org.assertj.core.api.Assertions.fail
 import org.junit.Assert.assertThrows
@@ -29,32 +30,32 @@ import org.junit.runners.JUnit4
 
 @RunWith(JUnit4::class)
 class StartFunctionTest {
+    private val counts = TextModuleCounts(0, 0, 0, 0, 0)
     private val tokenizer = Tokenizer()
-    private val context = ParseContext("StartFunctionTest.wast")
 
     @Test
     fun parse_returnsNull_ifDoesntStartWithOpenParen() {
-        val result = tokenizer.tokenize("start $0").parseStartFunction(0)
+        val result = tokenizer.tokenize("start $0").parseStartFunction(0, counts)
         assertThat(result).isNull()
     }
 
     @Test
     fun parse_returnsNull_ifKeywordIsNotStart() {
-        val result = tokenizer.tokenize("(end $0)").parseStartFunction(0)
+        val result = tokenizer.tokenize("(end $0)").parseStartFunction(0, counts)
         assertThat(result).isNull()
     }
 
     @Test
     fun throws_ifFunctionIndex_notFound() {
         assertThrows(ParseException::class.java) {
-            tokenizer.tokenize("(start )").parseStartFunction(0)
+            tokenizer.tokenize("(start )").parseStartFunction(0, counts)
         }
     }
 
     @Test
     fun throws_ifClosingParen_notFoundAfterFunctionIndex() {
         val e = assertThrows(ParseException::class.java) {
-            tokenizer.tokenize("(start $0").parseStartFunction(0)
+            tokenizer.tokenize("(start $0").parseStartFunction(0, counts)
         }
 
         assertThat(e).hasMessageThat().contains("Expected ')'")
@@ -62,8 +63,8 @@ class StartFunctionTest {
 
     @Test
     fun parses_startFunction() {
-        val result = tokenizer.tokenize("(start $0)").parseStartFunction(0)
-            ?: fail("Expected a result")
+        val (result, newCounts) = tokenizer.tokenize("(start $0)")
+            .parseStartFunction(0, counts) ?: fail("Expected a result")
 
         assertThat(result.parseLength).isEqualTo(4)
         assertThat(result.astNode)
@@ -74,16 +75,18 @@ class StartFunctionTest {
                     )
                 )
             )
+        assertThat(newCounts).isEqualTo(counts)
     }
 
     @Suppress("EXPERIMENTAL_UNSIGNED_LITERALS", "UNCHECKED_CAST")
     @Test
     fun parses_startFunction_withIntIndex() {
-        val result = tokenizer.tokenize("(start 123)").parseStartFunction(0)
-            ?: fail("Expected a result")
+        val (result, newCounts) = tokenizer.tokenize("(start 123)")
+            .parseStartFunction(0, counts) ?: fail("Expected a result")
 
         assertThat(result.parseLength).isEqualTo(4)
         assertThat(result.astNode)
             .isEqualTo(StartFunction(Index.ByInt(123) as Index<Identifier.Function>))
+        assertThat(newCounts).isEqualTo(counts)
     }
 }

--- a/library/src/test/java/kwasm/format/text/module/WasmModuleTest.kt
+++ b/library/src/test/java/kwasm/format/text/module/WasmModuleTest.kt
@@ -55,7 +55,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
-@Suppress("EXPERIMENTAL_UNSIGNED_LITERALS", "EXPERIMENTAL_API_USAGE")
+@Suppress("EXPERIMENTAL_UNSIGNED_LITERALS", "EXPERIMENTAL_API_USAGE", "UNCHECKED_CAST")
 @RunWith(JUnit4::class)
 class WasmModuleTest {
     private val tokenizer = Tokenizer()
@@ -297,25 +297,25 @@ class WasmModuleTest {
                 Export(
                     "a",
                     ExportDescriptor.Function(
-                        Index.ByIdentifier(Identifier.Function("$7"))
+                        Index.ByInt(3) as Index<Identifier.Function>
                     )
                 ),
                 Export(
                     "a",
                     ExportDescriptor.Table(
-                        Index.ByIdentifier(Identifier.Table("$9"))
+                        Index.ByInt(2) as Index<Identifier.Table>
                     )
                 ),
                 Export(
                     "a",
                     ExportDescriptor.Memory(
-                        Index.ByIdentifier(Identifier.Memory("$11"))
+                        Index.ByInt(2) as Index<Identifier.Memory>
                     )
                 ),
                 Export(
                     "a",
                     ExportDescriptor.Global(
-                        Index.ByIdentifier(Identifier.Global("$13"))
+                        Index.ByInt(2) as Index<Identifier.Global>
                     )
                 )
             ).inOrder()

--- a/library/src/test/java/kwasm/runtime/FunctionInstanceTest.kt
+++ b/library/src/test/java/kwasm/runtime/FunctionInstanceTest.kt
@@ -19,6 +19,7 @@ import kwasm.KWasmRuntimeException
 import kwasm.ParseRule
 import kwasm.api.UnitHostFunction
 import kwasm.api.functionType
+import kwasm.format.text.TextModuleCounts
 import kwasm.format.text.module.parseWasmFunction
 import kwasm.runtime.FunctionInstance.Companion.allocate
 import kwasm.runtime.stack.RuntimeStacks
@@ -34,6 +35,7 @@ import org.junit.runners.JUnit4
 class FunctionInstanceTest {
     @get:Rule
     val parser = ParseRule()
+    private val counts = TextModuleCounts(0, 0, 0, 0, 0)
 
     private val emptyContext: ExecutionContext
         get() = ExecutionContext(
@@ -54,7 +56,7 @@ class FunctionInstanceTest {
         val fn =
             """
             (func)
-            """.trimIndent().tokenize().parseWasmFunction(0)!!.astNode
+            """.trimIndent().tokenize().parseWasmFunction(0, counts)!!.first.astNode
 
         val store = Store()
         val moduleInstance = ModuleInstance(

--- a/library/src/test/java/kwasm/runtime/utils/Tools.kt
+++ b/library/src/test/java/kwasm/runtime/utils/Tools.kt
@@ -25,6 +25,7 @@ import kwasm.ast.instruction.flatten
 import kwasm.ast.module.Index
 import kwasm.ast.module.WasmFunction
 import kwasm.ast.util.toFunctionIndex
+import kwasm.format.text.TextModuleCounts
 import kwasm.format.text.module.parseWasmFunction
 import kwasm.runtime.Address
 import kwasm.runtime.ExecutionContext
@@ -182,7 +183,10 @@ internal class TestCase(
 
     override fun checkFunction(source: String): ExecutionContext {
         var wasmFunction: WasmFunction? = null
-        parser.with { wasmFunction = source.tokenize().parseWasmFunction(0)!!.astNode }
+        val counts = TextModuleCounts(0, 0, 0, 0, 0)
+        parser.with {
+            wasmFunction = source.tokenize().parseWasmFunction(0, counts)!!.first.astNode
+        }
 
         val resultContext = FunctionInstance.Module(context.moduleInstance, wasmFunction!!)
             .execute(context.withOpStack(opStack.map { it.toValue() }))
@@ -225,7 +229,10 @@ internal class ErrorTestCase(
 
     override fun checkFunction(source: String): ExecutionContext {
         var wasmFunction: WasmFunction? = null
-        parser.with { wasmFunction = source.tokenize().parseWasmFunction(0)!!.astNode }
+        val counts = TextModuleCounts(0, 0, 0, 0, 0)
+        parser.with {
+            wasmFunction = source.tokenize().parseWasmFunction(0, counts)!!.first.astNode
+        }
 
         assertThrows(expectedThrowable.java) {
             FunctionInstance.Module(context.moduleInstance, wasmFunction!!).execute(


### PR DESCRIPTION
For text-parsing, this changes how Identifiers are parsed for module-level components (functions, types, tables, etc.) by always assigning Indexes based on position, and keeping a running value of the total number of each component seen so far - which can be used to determine what an unspecified identifier's index value should be.

Fixes: #265 