### PR TITLE
Enable address.wast and align.wast spec tests.

### DIFF
--- a/library/src/main/java/kwasm/KWasmProgram.kt
+++ b/library/src/main/java/kwasm/KWasmProgram.kt
@@ -488,6 +488,7 @@ class KWasmProgram internal constructor(
 
         internal fun withModule(name: String, module: WasmModule) {
             parsedModules[name] = module
+            modulesInOrder.removeIf { it.first == name }
             modulesInOrder.add(name to module)
         }
 

--- a/library/src/main/java/kwasm/ast/instruction/MemArg.kt
+++ b/library/src/main/java/kwasm/ast/instruction/MemArg.kt
@@ -40,13 +40,18 @@ class MemArg(
         get() = this
 
     /**
+     * Returns whether or not the value of [alignment] is well-formed at parse time.
+     * It must be a power of 2.
+     */
+    fun isAlignmentWellFormed(): Boolean =
+        alignment != 0 && log(alignment.toFloat(), 2.0f).let { floor(it) == it }
+
+    /**
      * Returns whether or not the value of [alignment] is valid for the given [forByteWidth]
      * upper-bound.
      */
-    fun isAlignmentValid(forByteWidth: Int? = null) =
-        log(alignment.toFloat(), 2.0f)
-            // If it's a power of 2, and it's less than or equal to 2^forN, then it's valid.
-            .let { floor(it) == it && (forByteWidth == null || alignment <= forByteWidth * 8) }
+    fun isAlignmentValid(forByteWidth: Int? = null): Boolean =
+        isAlignmentWellFormed() && (forByteWidth == null || alignment <= forByteWidth)
 
     /** Returns a canonical instance of [MemArg] matching this one, if it exists. */
     override fun deDupe(): MemArg = when (this) {
@@ -78,9 +83,9 @@ class MemArg(
     override fun toString(): String = "MemArg(offset=$offset, alignment=$alignment)"
 
     companion object {
-        internal val ONE = MemArg(0, 8)
-        internal val TWO = MemArg(0, 16)
-        internal val FOUR = MemArg(0, 32)
-        internal val EIGHT = MemArg(0, 64)
+        internal val ONE = MemArg(0, 1)
+        internal val TWO = MemArg(0, 2)
+        internal val FOUR = MemArg(0, 4)
+        internal val EIGHT = MemArg(0, 8)
     }
 }

--- a/library/src/main/java/kwasm/format/binary/module/Locals.kt
+++ b/library/src/main/java/kwasm/format/binary/module/Locals.kt
@@ -23,7 +23,6 @@ import kwasm.format.binary.value.readUInt
 import kwasm.format.binary.value.readVector
 import kwasm.format.binary.value.toBytesAsVector
 import kwasm.util.Leb128
-import kotlin.math.pow
 
 /**
  * From [the code section docs](https://webassembly.github.io/spec/core/binary/modules.html#code-section):
@@ -46,8 +45,8 @@ fun BinaryParser.readFuncLocals(): List<Local> {
         val count = readUInt()
         val type = readValueType()
         mutableListOf<ValueType>().apply {
-            if (count >= 2.0.pow(29)) {
-                throwException("Cannot parse func locals - too many locals", -2)
+            if (count.toUInt() > Int.MAX_VALUE.toUInt()) {
+                throwException("Cannot parse func locals (too many locals)", -2)
             }
             repeat(count) { add(type) }
         }

--- a/library/src/main/java/kwasm/format/text/instruction/MemArg.kt
+++ b/library/src/main/java/kwasm/format/text/instruction/MemArg.kt
@@ -39,13 +39,7 @@ import kwasm.format.text.token.Token
 fun List<Token>.parseMemarg(fromIndex: Int, expectedMaxBytes: Int): ParseResult<MemArg> {
     var currentIndex = fromIndex
     val firstKeyword = getOrNull(currentIndex) as? Keyword
-        ?: return ParseResult(
-            MemArg(
-                0,
-                expectedMaxBytes * 8
-            ).deDupe(),
-            0
-        )
+        ?: return ParseResult(MemArg(0, expectedMaxBytes).deDupe(), 0)
 
     val memArg = when {
         firstKeyword.value.startsWith("offset=") -> {
@@ -67,7 +61,7 @@ fun List<Token>.parseMemarg(fromIndex: Int, expectedMaxBytes: Int): ParseResult<
                 }
             MemArg(
                 offset.toInt(),
-                alignment?.toInt() ?: expectedMaxBytes * 8
+                alignment?.toInt() ?: expectedMaxBytes
             )
         }
         firstKeyword.value.startsWith("align=") -> {
@@ -79,11 +73,11 @@ fun List<Token>.parseMemarg(fromIndex: Int, expectedMaxBytes: Int): ParseResult<
             ).value
             MemArg(0, alignment.toInt())
         }
-        else -> MemArg(0, expectedMaxBytes * 8)
+        else -> MemArg(0, expectedMaxBytes)
     }
 
-    parseCheck(contextAt(fromIndex), memArg.isAlignmentValid(expectedMaxBytes)) {
-        "Illegal MemArg value for N=$expectedMaxBytes"
+    parseCheck(contextAt(fromIndex), memArg.isAlignmentWellFormed()) {
+        "Illegal MemArg value for N=$expectedMaxBytes (alignment)"
     }
 
     return ParseResult(

--- a/library/src/main/java/kwasm/format/text/module/DataSegment.kt
+++ b/library/src/main/java/kwasm/format/text/module/DataSegment.kt
@@ -26,6 +26,7 @@ import kwasm.format.text.isKeyword
 import kwasm.format.text.isOpenParen
 import kwasm.format.text.token.StringLiteral
 import kwasm.format.text.token.Token
+import java.util.stream.Collectors
 
 /**
  * Parses a [DataSegment] from the receiving [List] of [Token]s.
@@ -93,5 +94,8 @@ internal fun List<Token>.parseDataString(fromIndex: Int): Pair<ByteArray, Int> {
             currentIndex++
         } else break
     }
-    return strings.toString().toByteArray(Charsets.UTF_8) to (currentIndex - fromIndex)
+    val bytes = strings.codePoints().mapToObj { it.toByte() }
+        .collect(Collectors.toList())
+    val byteArray = ByteArray(bytes.size) { bytes[it] }
+    return byteArray to (currentIndex - fromIndex)
 }

--- a/library/src/main/java/kwasm/format/text/module/WasmModule.kt
+++ b/library/src/main/java/kwasm/format/text/module/WasmModule.kt
@@ -141,7 +141,7 @@ fun List<Token>.parseModule(fromIndex: Int): ParseResult<WasmModule>? {
 
     return ParseResult(
         WasmModule(
-            label.astNode,
+            label.astNode.takeIf { it.stringRepr != null },
             types,
             imports,
             functions,

--- a/library/src/main/java/kwasm/format/text/token/FloatLiteral.kt
+++ b/library/src/main/java/kwasm/format/text/token/FloatLiteral.kt
@@ -88,7 +88,7 @@ class FloatLiteral(
                     nValue.toLong() >= 2.0.pow(magnitude.significand(context))
                 ) throw ParseException("Illegal hex NaN value.")
 
-                CanonincalNaN(magnitude).value.toDouble()
+                if (magnitude == 32) NAN_32_VALUE else NAN_64_VALUE
             }
             else -> {
                 val (sequenceOffset, sign) = sequence.parseLongSign()

--- a/library/src/main/java/kwasm/runtime/instruction/MemoryInstruction.kt
+++ b/library/src/main/java/kwasm/runtime/instruction/MemoryInstruction.kt
@@ -78,7 +78,11 @@ internal fun MemoryInstruction.LoadInt.execute(context: ExecutionContext): Execu
     val memory = context.getMemory()
     val memAddress = (context.stacks.operands.pop() as? IntValue)
         ?: throw KWasmRuntimeException("Memory loading requires i32 on top of the stack")
+    val eaLong = memAddress.unsignedValue.toLong() + arg.offset.toLong()
     val ea = (memAddress.unsignedValue + arg.offset).toInt()
+    if (ea < eaLong) {
+        throw KWasmRuntimeException("Cannot load at position $eaLong (out of bounds memory access)")
+    }
     val resultValue = try {
         when (byteWidth) {
             // i32 requested.
@@ -108,7 +112,11 @@ internal fun MemoryInstruction.LoadFloat.execute(context: ExecutionContext): Exe
     val memory = context.getMemory()
     val memAddress = (context.stacks.operands.pop() as? IntValue)
         ?: throw KWasmRuntimeException("Memory loading requires i32 on top of the stack")
+    val eaLong = memAddress.unsignedValue.toLong() + arg.offset.toLong()
     val ea = (memAddress.unsignedValue + arg.offset).toInt()
+    if (ea < eaLong) {
+        throw KWasmRuntimeException("Cannot load at position $eaLong (out of bounds memory access)")
+    }
     val resultValue = try {
         when (byteWidth) {
             // f32 requested.
@@ -175,7 +183,10 @@ internal fun MemoryInstruction.StoreInt.execute(context: ExecutionContext): Exec
             try {
                 memory.writeULong(longValue.unsignedValue, ea, storageBytes)
             } catch (e: IndexOutOfBoundsException) {
-                throw KWasmRuntimeException("Cannot store at position $ea", e)
+                throw KWasmRuntimeException(
+                    "Cannot store at position $ea (out of bounds memory access)",
+                    e
+                )
             } catch (e: IllegalArgumentException) {
                 throw KWasmRuntimeException("Cannot store at position $ea", e)
             }

--- a/library/src/main/java/kwasm/runtime/memory/ByteBufferMemory.kt
+++ b/library/src/main/java/kwasm/runtime/memory/ByteBufferMemory.kt
@@ -142,9 +142,12 @@ internal class ByteBufferMemory(
         if (byteWidth == 4 && offset % PAGE_SIZE < PAGE_SIZE - 4) {
             // Simple case... use ByteBuffer directly.
             pages[currentPage].putInt(offset % PAGE_SIZE, value)
-        } else {
+        } else if ((offset + byteWidth) / PAGE_SIZE < pages.size) {
             pages.writeInt(value, offset, byteWidth)
-        }
+        } else throw IndexOutOfBoundsException(
+            "Data at $offset with width $byteWidth would overflow into " +
+                "a page that does not exist yet."
+        )
     }
 
     override fun writeUInt(value: UInt, offset: Int, byteWidth: Int, alignment: Int) {
@@ -154,9 +157,12 @@ internal class ByteBufferMemory(
         if (byteWidth == 4 && offset % PAGE_SIZE < PAGE_SIZE - 4) {
             // Simple case... use ByteBuffer directly.
             pages[currentPage].putInt(offset % PAGE_SIZE, value.toInt())
-        } else {
+        } else if ((offset + byteWidth) / PAGE_SIZE < pages.size) {
             pages.writeUInt(value, offset, byteWidth)
-        }
+        } else throw IndexOutOfBoundsException(
+            "Data at $offset with width $byteWidth would overflow into " +
+                "a page that does not exist yet."
+        )
     }
 
     override fun writeLong(value: Long, offset: Int, byteWidth: Int, alignment: Int) {
@@ -166,9 +172,12 @@ internal class ByteBufferMemory(
         if (byteWidth == 8 && offset % PAGE_SIZE < PAGE_SIZE - 8) {
             // Simple case... use ByteBuffer directly.
             pages[currentPage].putLong(offset % PAGE_SIZE, value)
-        } else {
+        } else if ((offset + byteWidth) / PAGE_SIZE < pages.size) {
             pages.writeLong(value, offset, byteWidth)
-        }
+        } else throw IndexOutOfBoundsException(
+            "Data at $offset with width $byteWidth would overflow into " +
+                "a page that does not exist yet."
+        )
     }
 
     override fun writeULong(value: ULong, offset: Int, byteWidth: Int, alignment: Int) {
@@ -178,9 +187,12 @@ internal class ByteBufferMemory(
         if (byteWidth == 8 && offset % PAGE_SIZE < PAGE_SIZE - 8) {
             // Simple case... use ByteBuffer directly.
             pages[currentPage].putLong(offset % PAGE_SIZE, value.toLong())
-        } else {
+        } else if ((offset + byteWidth) / PAGE_SIZE < pages.size) {
             pages.writeULong(value, offset, byteWidth)
-        }
+        } else throw IndexOutOfBoundsException(
+            "Data at $offset with width $byteWidth would overflow into " +
+                "a page that does not exist yet."
+        )
     }
 
     override fun writeFloat(value: Float, offset: Int, alignment: Int) {
@@ -189,9 +201,12 @@ internal class ByteBufferMemory(
         if (offset % PAGE_SIZE < PAGE_SIZE - 4) {
             // Simple case... use ByteBuffer directly.
             pages[currentPage].putFloat(offset % PAGE_SIZE, value)
-        } else {
+        } else if ((offset + 4) / PAGE_SIZE < pages.size) {
             pages.writeFloat(value, offset)
-        }
+        } else throw IndexOutOfBoundsException(
+            "Data at $offset with width 4 would overflow into " +
+                "a page that does not exist yet."
+        )
     }
 
     override fun writeDouble(value: Double, offset: Int, alignment: Int) {
@@ -200,9 +215,12 @@ internal class ByteBufferMemory(
         if (offset % PAGE_SIZE < PAGE_SIZE - 8) {
             // Simple case... use ByteBuffer directly.
             pages[currentPage].putDouble(offset % PAGE_SIZE, value)
-        } else {
+        } else if ((offset + 8) / PAGE_SIZE < pages.size) {
             pages.writeDouble(value, offset)
-        }
+        } else throw IndexOutOfBoundsException(
+            "Data at $offset with width 8 would overflow into " +
+                "a page that does not exist yet."
+        )
     }
 
     override fun readBytes(

--- a/library/src/main/java/kwasm/validation/instruction/memory/LoadFloatValidator.kt
+++ b/library/src/main/java/kwasm/validation/instruction/memory/LoadFloatValidator.kt
@@ -42,7 +42,7 @@ object LoadFloatValidator : FunctionBodyValidationVisitor<MemoryInstruction.Load
     ): ValidationContext.FunctionBody {
         context.validateMemoryExists()
         validate(node.arg.isAlignmentValid(node.byteWidth), parseContext = null) {
-            "Invalid alignment for N=${node.byteWidth}"
+            "Invalid alignment for N=${node.byteWidth} (alignment must not be larger than natural)"
         }
         val (top, updatedContext) = context.popStack()
         validateNotNull(

--- a/library/src/main/java/kwasm/validation/instruction/memory/LoadIntValidator.kt
+++ b/library/src/main/java/kwasm/validation/instruction/memory/LoadIntValidator.kt
@@ -49,7 +49,8 @@ object LoadIntValidator : FunctionBodyValidationVisitor<MemoryInstruction.LoadIn
     ): ValidationContext.FunctionBody {
         context.validateMemoryExists()
         validate(node.arg.isAlignmentValid(node.storageBytes), parseContext = null) {
-            "Invalid alignment for N=${node.storageBits}"
+            "Invalid alignment (${node.arg}) for N=${node.storageBits} (alignment must not be " +
+                "larger than natural)"
         }
         val (top, updatedContext) = context.popStack()
         validateNotNull(

--- a/library/src/main/java/kwasm/validation/instruction/memory/StoreFloatValidator.kt
+++ b/library/src/main/java/kwasm/validation/instruction/memory/StoreFloatValidator.kt
@@ -41,7 +41,7 @@ object StoreFloatValidator : FunctionBodyValidationVisitor<MemoryInstruction.Sto
     ): ValidationContext.FunctionBody {
         context.validateMemoryExists()
         validate(node.arg.isAlignmentValid(node.byteWidth), parseContext = null) {
-            "Invalid alignment for N=${node.byteWidth}"
+            "Invalid alignment for N=${node.byteWidth} (alignment must not be larger than natural)"
         }
         val (topTwo, updatedContext) = context.popStack(2)
         val storeType = when (node.bitWidth) {

--- a/library/src/main/java/kwasm/validation/instruction/memory/StoreIntValidator.kt
+++ b/library/src/main/java/kwasm/validation/instruction/memory/StoreIntValidator.kt
@@ -48,7 +48,8 @@ object StoreIntValidator : FunctionBodyValidationVisitor<MemoryInstruction.Store
     ): ValidationContext.FunctionBody {
         context.validateMemoryExists()
         validate(node.arg.isAlignmentValid(node.storageBytes), parseContext = null) {
-            "Invalid alignment for N=${node.storageBytes}"
+            "Invalid alignment for N=${node.storageBytes} (alignment must not be " +
+                "larger than natural)"
         }
         val (topTwo, updatedContext) = context.popStack(2)
         val storeType = when (node.bitWidth) {

--- a/library/src/test/java/kwasm/format/text/instruction/MemArgTest.kt
+++ b/library/src/test/java/kwasm/format/text/instruction/MemArgTest.kt
@@ -54,21 +54,11 @@ class MemArgTest {
     fun parse_offsetOnly() {
         var result = tokenizer.tokenize("offset=50", context).parseMemarg(0, 4)
         assertThat(result.parseLength).isEqualTo(1)
-        assertThat(result.astNode).isEqualTo(
-            MemArg(
-                50,
-                32
-            )
-        )
+        assertThat(result.astNode).isEqualTo(MemArg(50, 4))
 
         result = tokenizer.tokenize("offset=50 call", context).parseMemarg(0, 4)
         assertThat(result.parseLength).isEqualTo(1)
-        assertThat(result.astNode).isEqualTo(
-            MemArg(
-                50,
-                32
-            )
-        )
+        assertThat(result.astNode).isEqualTo(MemArg(50, 4))
     }
 
     @Test
@@ -93,12 +83,12 @@ class MemArgTest {
     @Test
     fun throws_whenAlignIsIllegal() {
         var e = assertThrows(ParseException::class.java) {
-            tokenizer.tokenize("offset=50 align=64", context).parseMemarg(0, 4)
+            tokenizer.tokenize("offset=50 align=5", context).parseMemarg(0, 4)
         }
         assertThat(e).hasMessageThat().contains("Illegal MemArg value for N=4")
 
         e = assertThrows(ParseException::class.java) {
-            tokenizer.tokenize("align=64", context).parseMemarg(0, 4)
+            tokenizer.tokenize("align=35", context).parseMemarg(0, 4)
         }
         assertThat(e).hasMessageThat().contains("Illegal MemArg value for N=4")
     }

--- a/library/src/test/java/kwasm/format/text/instruction/MemoryInstructionTest.kt
+++ b/library/src/test/java/kwasm/format/text/instruction/MemoryInstructionTest.kt
@@ -52,7 +52,7 @@ class MemoryInstructionTest {
 
     @Test
     fun parses_i32Load_withMemarg() {
-        val result = parseMemoryInstruction("i32.load offset=0 align=32")
+        val result = parseMemoryInstruction("i32.load offset=0 align=4")
 
         assertThat(result.parseLength).isEqualTo(3)
         assertThat(result.astNode).isEqualTo(
@@ -74,7 +74,7 @@ class MemoryInstructionTest {
 
     @Test
     fun parses_i64Load_withMemarg() {
-        val result = parseMemoryInstruction("i64.load offset=0 align=64")
+        val result = parseMemoryInstruction("i64.load offset=0 align=8")
 
         assertThat(result.parseLength).isEqualTo(3)
         assertThat(result.astNode).isEqualTo(
@@ -96,7 +96,7 @@ class MemoryInstructionTest {
 
     @Test
     fun parses_f32Load_withMemarg() {
-        val result = parseMemoryInstruction("f32.load offset=0 align=32")
+        val result = parseMemoryInstruction("f32.load offset=0 align=4")
 
         assertThat(result.parseLength).isEqualTo(3)
         assertThat(result.astNode).isEqualTo(
@@ -118,7 +118,7 @@ class MemoryInstructionTest {
 
     @Test
     fun parses_f64Load_withMemarg() {
-        val result = parseMemoryInstruction("f64.load offset=0 align=64")
+        val result = parseMemoryInstruction("f64.load offset=0 align=8")
 
         assertThat(result.parseLength).isEqualTo(3)
         assertThat(result.astNode).isEqualTo(
@@ -140,7 +140,7 @@ class MemoryInstructionTest {
 
     @Test
     fun parses_i32Load8_s_withMemarg() {
-        val result = parseMemoryInstruction("i32.load8_s offset=0 align=8")
+        val result = parseMemoryInstruction("i32.load8_s offset=0 align=1")
 
         assertThat(result.parseLength).isEqualTo(3)
         assertThat(result.astNode).isEqualTo(
@@ -162,7 +162,7 @@ class MemoryInstructionTest {
 
     @Test
     fun parses_i32Load8_u_withMemarg() {
-        val result = parseMemoryInstruction("i32.load8_u offset=0 align=8")
+        val result = parseMemoryInstruction("i32.load8_u offset=0 align=1")
 
         assertThat(result.parseLength).isEqualTo(3)
         assertThat(result.astNode).isEqualTo(
@@ -184,7 +184,7 @@ class MemoryInstructionTest {
 
     @Test
     fun parses_i32Load16_s_withMemarg() {
-        val result = parseMemoryInstruction("i32.load16_s offset=0 align=16")
+        val result = parseMemoryInstruction("i32.load16_s offset=0 align=2")
 
         assertThat(result.parseLength).isEqualTo(3)
         assertThat(result.astNode).isEqualTo(
@@ -206,7 +206,7 @@ class MemoryInstructionTest {
 
     @Test
     fun parses_i32Load16_u_withMemarg() {
-        val result = parseMemoryInstruction("i32.load16_u offset=0 align=16")
+        val result = parseMemoryInstruction("i32.load16_u offset=0 align=2")
 
         assertThat(result.parseLength).isEqualTo(3)
         assertThat(result.astNode).isEqualTo(
@@ -228,7 +228,7 @@ class MemoryInstructionTest {
 
     @Test
     fun parses_i64Load8_s_withMemarg() {
-        val result = parseMemoryInstruction("i64.load8_s offset=0 align=8")
+        val result = parseMemoryInstruction("i64.load8_s offset=0 align=1")
 
         assertThat(result.parseLength).isEqualTo(3)
         assertThat(result.astNode).isEqualTo(
@@ -250,7 +250,7 @@ class MemoryInstructionTest {
 
     @Test
     fun parses_i64Load8_u_withMemarg() {
-        val result = parseMemoryInstruction("i64.load8_u offset=0 align=8")
+        val result = parseMemoryInstruction("i64.load8_u offset=0 align=1")
 
         assertThat(result.parseLength).isEqualTo(3)
         assertThat(result.astNode).isEqualTo(
@@ -272,7 +272,7 @@ class MemoryInstructionTest {
 
     @Test
     fun parses_i64Load16_s_withMemarg() {
-        val result = parseMemoryInstruction("i64.load16_s offset=0 align=16")
+        val result = parseMemoryInstruction("i64.load16_s offset=0 align=2")
 
         assertThat(result.parseLength).isEqualTo(3)
         assertThat(result.astNode).isEqualTo(
@@ -294,7 +294,7 @@ class MemoryInstructionTest {
 
     @Test
     fun parses_i64Load16_u_withMemarg() {
-        val result = parseMemoryInstruction("i64.load16_u offset=0 align=16")
+        val result = parseMemoryInstruction("i64.load16_u offset=0 align=2")
 
         assertThat(result.parseLength).isEqualTo(3)
         assertThat(result.astNode).isEqualTo(
@@ -316,7 +316,7 @@ class MemoryInstructionTest {
 
     @Test
     fun parses_i64Load32_s_withMemarg() {
-        val result = parseMemoryInstruction("i64.load32_s offset=0 align=32")
+        val result = parseMemoryInstruction("i64.load32_s offset=0 align=4")
 
         assertThat(result.parseLength).isEqualTo(3)
         assertThat(result.astNode).isEqualTo(
@@ -338,7 +338,7 @@ class MemoryInstructionTest {
 
     @Test
     fun parses_i64Load32_u_withMemarg() {
-        val result = parseMemoryInstruction("i64.load32_u offset=0 align=32")
+        val result = parseMemoryInstruction("i64.load32_u offset=0 align=4")
 
         assertThat(result.parseLength).isEqualTo(3)
         assertThat(result.astNode).isEqualTo(
@@ -360,7 +360,7 @@ class MemoryInstructionTest {
 
     @Test
     fun parses_i32Store_withMemarg() {
-        val result = parseMemoryInstruction("i32.store offset=0 align=32")
+        val result = parseMemoryInstruction("i32.store offset=0 align=4")
 
         assertThat(result.parseLength).isEqualTo(3)
         assertThat(result.astNode).isEqualTo(
@@ -382,7 +382,7 @@ class MemoryInstructionTest {
 
     @Test
     fun parses_i32Store8_withMemarg() {
-        val result = parseMemoryInstruction("i32.store8 offset=0 align=8")
+        val result = parseMemoryInstruction("i32.store8 offset=0 align=1")
 
         assertThat(result.parseLength).isEqualTo(3)
         assertThat(result.astNode).isEqualTo(
@@ -404,7 +404,7 @@ class MemoryInstructionTest {
 
     @Test
     fun parses_i32Store16_withMemarg() {
-        val result = parseMemoryInstruction("i32.store16 offset=0 align=16")
+        val result = parseMemoryInstruction("i32.store16 offset=0 align=2")
 
         assertThat(result.parseLength).isEqualTo(3)
         assertThat(result.astNode).isEqualTo(
@@ -426,7 +426,7 @@ class MemoryInstructionTest {
 
     @Test
     fun parses_i64Store8_withMemarg() {
-        val result = parseMemoryInstruction("i64.store8 offset=0 align=8")
+        val result = parseMemoryInstruction("i64.store8 offset=0 align=1")
 
         assertThat(result.parseLength).isEqualTo(3)
         assertThat(result.astNode).isEqualTo(
@@ -448,7 +448,7 @@ class MemoryInstructionTest {
 
     @Test
     fun parses_i64Store16_withMemarg() {
-        val result = parseMemoryInstruction("i64.store16 offset=0 align=16")
+        val result = parseMemoryInstruction("i64.store16 offset=0 align=2")
 
         assertThat(result.parseLength).isEqualTo(3)
         assertThat(result.astNode).isEqualTo(
@@ -470,7 +470,7 @@ class MemoryInstructionTest {
 
     @Test
     fun parses_i64Store32_withMemarg() {
-        val result = parseMemoryInstruction("i64.store32 offset=0 align=32")
+        val result = parseMemoryInstruction("i64.store32 offset=0 align=4")
 
         assertThat(result.parseLength).isEqualTo(3)
         assertThat(result.astNode).isEqualTo(
@@ -492,7 +492,7 @@ class MemoryInstructionTest {
 
     @Test
     fun parses_f32Store_withMemarg() {
-        val result = parseMemoryInstruction("f32.store offset=0 align=32")
+        val result = parseMemoryInstruction("f32.store offset=0 align=4")
 
         assertThat(result.parseLength).isEqualTo(3)
         assertThat(result.astNode).isEqualTo(
@@ -514,7 +514,7 @@ class MemoryInstructionTest {
 
     @Test
     fun parses_f64Store_withMemarg() {
-        val result = parseMemoryInstruction("f64.store offset=0 align=64")
+        val result = parseMemoryInstruction("f64.store offset=0 align=8")
 
         assertThat(result.parseLength).isEqualTo(3)
         assertThat(result.astNode).isEqualTo(

--- a/library/src/test/java/kwasm/runtime/memory/ByteBufferMemoryTest.kt
+++ b/library/src/test/java/kwasm/runtime/memory/ByteBufferMemoryTest.kt
@@ -563,7 +563,8 @@ class ByteBufferMemoryTest {
                 .toList()
                 .shuffled(Random(System.nanoTime()))
                 .take(3)
-        val expectedFinalValue = values[beforeLockDelays.withIndex().maxBy { it.value }!!.index]
+        val expectedFinalValue =
+            values[beforeLockDelays.withIndex().maxByOrNull { it.value }!!.index]
 
         val jobOne = launch {
             delay(beforeLockDelays[0])

--- a/library/src/test/java/kwasm/spectests/CoreSpecTest.kt
+++ b/library/src/test/java/kwasm/spectests/CoreSpecTest.kt
@@ -23,7 +23,12 @@ import java.io.InputStreamReader
 class CoreSpecTest {
     @SpecTest(
         subdir = "core",
-        files = ["binary.wast", "traps.wast"],
+        files = [
+            "address.wast",
+            "align.wast",
+            "binary.wast",
+            "traps.wast"
+        ],
     )
     fun scriptTest(input: InputStream, file: String) {
         runScript(InputStreamReader(input), ParseContext(file))

--- a/library/src/test/java/kwasm/spectests/command/ScriptModule.kt
+++ b/library/src/test/java/kwasm/spectests/command/ScriptModule.kt
@@ -58,13 +58,14 @@ sealed class ScriptModule : Command<Unit> {
         val source: String
     ) : ScriptModule() {
         override fun execute(context: ScriptContext) {
+            val moduleSource = if (source.startsWith("(module")) source else "(module $source)"
             val module = Tokenizer().tokenize(
-                "(module $source)",
+                moduleSource,
                 parseContext
             ).parseModule(0)!!.astNode
 
             context.modules[identifier] = module
-            context.programBuilder.withModule("", "(module $source)")
+            context.programBuilder.withModule("", moduleSource)
             context.build()
         }
     }


### PR DESCRIPTION
Also involved fixing some issues with MemArg alignment parsing and validation.

Related Issue(s): #148 
