### PR TITLE
Enable binary-leb128.wast

### DIFF
--- a/library/src/main/java/kwasm/format/binary/value/Vector.kt
+++ b/library/src/main/java/kwasm/format/binary/value/Vector.kt
@@ -39,7 +39,7 @@ fun BinaryParser.readVector(): List<Byte> = readVector { readByte() }
  */
 @Suppress("EXPERIMENTAL_API_USAGE")
 fun <T> BinaryParser.readVector(block: BinaryParser.() -> T): List<T> {
-    val size = readInt()
+    val size = readUInt()
     if (size >= Int.MAX_VALUE.toLong() || size < 0) throwException("vector too long")
     return (0 until size).map { block() }
 }

--- a/library/src/main/java/kwasm/validation/instruction/InstructionSequenceValidator.kt
+++ b/library/src/main/java/kwasm/validation/instruction/InstructionSequenceValidator.kt
@@ -15,6 +15,7 @@
 package kwasm.validation.instruction
 
 import kwasm.ast.AstNodeList
+import kwasm.ast.instruction.ControlInstruction
 import kwasm.ast.instruction.Instruction
 import kwasm.ast.type.ValueType
 import kwasm.validation.ValidationContext
@@ -73,7 +74,10 @@ class InstructionSequenceValidator(
         node: AstNodeList<out Instruction>,
         context: ValidationContext.FunctionBody
     ): ValidationContext.FunctionBody {
-        val resultContext = node.fold(context) { ctx, inst -> inst.validate(ctx) }
+        val resultContext = node.fold(context) { ctx, inst ->
+            if (inst == ControlInstruction.Unreachable) return ctx
+            inst.validate(ctx)
+        }
         requiredEndStack?.let {
             val topElements = resultContext.stack.takeLast(it.size)
             validate(topElements == it, parseContext = null) {

--- a/library/src/test/java/kwasm/format/binary/value/IntegerValueTest.kt
+++ b/library/src/test/java/kwasm/format/binary/value/IntegerValueTest.kt
@@ -15,8 +15,10 @@
 package kwasm.format.binary.value
 
 import com.google.common.truth.Truth.assertThat
+import kwasm.format.ParseException
 import kwasm.format.binary.BinaryParser
 import kwasm.format.binary.toByteArray
+import org.junit.Assert.assertThrows
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
@@ -25,6 +27,26 @@ import java.io.ByteArrayInputStream
 @Suppress("EXPERIMENTAL_UNSIGNED_LITERALS")
 @RunWith(JUnit4::class)
 class IntegerValueTest {
+    @Test
+    fun readUInt_throwsOnUnusedOnes() {
+        val bytes = listOf(0x82, 0x80, 0x80, 0x80, 0x10).toByteArray()
+        val parser = BinaryParser(ByteArrayInputStream(bytes))
+
+        val e = assertThrows(ParseException::class.java) {
+            parser.readUInt()
+        }
+    }
+
+    @Test
+    fun readULong_throwsOnUnusedOnes() {
+        val bytes = listOf(0x82, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x7F).toByteArray()
+        val parser = BinaryParser(ByteArrayInputStream(bytes))
+
+        val e = assertThrows(ParseException::class.java) {
+            parser.readUInt()
+        }
+    }
+
     @Test
     fun readUInt_readsZero() {
         val bytes = ByteArray(1) { 0x00 }

--- a/library/src/test/java/kwasm/spectests/CoreSpecTest.kt
+++ b/library/src/test/java/kwasm/spectests/CoreSpecTest.kt
@@ -14,7 +14,12 @@
 
 package kwasm.spectests
 
+import kwasm.KWasmProgram
+import kwasm.api.ByteBufferMemoryProvider
+import kwasm.api.HostFunction
 import kwasm.format.ParseContext
+import kwasm.runtime.EmptyValue
+import kwasm.runtime.IntValue
 import org.junit.runner.RunWith
 import java.io.InputStream
 import java.io.InputStreamReader
@@ -27,10 +32,18 @@ class CoreSpecTest {
             "address.wast",
             "align.wast",
             "binary.wast",
+            "binary-leb128.wast",
             "traps.wast"
         ],
     )
     fun scriptTest(input: InputStream, file: String) {
-        runScript(InputStreamReader(input), ParseContext(file))
+        val builder = KWasmProgram.builder(ByteBufferMemoryProvider(1024 * 1024))
+        builder.withHostFunction(
+            "spectest",
+            "print_i32",
+            HostFunction { p1: IntValue, _ -> println(p1.value); EmptyValue }
+        )
+
+        runScript(InputStreamReader(input), ParseContext(file), builder)
     }
 }

--- a/library/src/test/java/kwasm/spectests/Script.kt
+++ b/library/src/test/java/kwasm/spectests/Script.kt
@@ -14,6 +14,7 @@
 
 package kwasm.spectests
 
+import kwasm.KWasmProgram
 import kwasm.format.ParseContext
 import kwasm.format.text.Tokenizer
 import kwasm.format.text.token.Token
@@ -21,13 +22,13 @@ import kwasm.spectests.command.parseAndRunCommand
 import kwasm.spectests.execution.ScriptContext
 import java.io.Reader
 
-fun runScript(input: Reader, parseContext: ParseContext) {
-    runScript(Tokenizer().tokenize(input, parseContext))
+fun runScript(input: Reader, parseContext: ParseContext, programBuilder: KWasmProgram.Builder) {
+    runScript(Tokenizer().tokenize(input, parseContext), programBuilder)
 }
 
-fun runScript(tokens: List<Token>) {
+fun runScript(tokens: List<Token>, programBuilder: KWasmProgram.Builder) {
     var position = 0
-    val scriptContext = ScriptContext()
+    val scriptContext = ScriptContext(programBuilder = programBuilder)
     while (position < tokens.size) {
         val result = tokens.parseAndRunCommand(position, scriptContext)
         position += result.parseLength


### PR DESCRIPTION
This involved some fixes to error handling in LEB 128 parsing, as well as some minor tweaks to instruction sequence validation (unreachables imply the remainder of a sequence can be skipped), and vector length parsing is now [correctly] using readUInt, instead of readInt.

Related Issue(s): #148 