### PR TITLE
Get const.wast to pass.

### DIFF
--- a/library/src/main/java/kwasm/format/ParseException.kt
+++ b/library/src/main/java/kwasm/format/ParseException.kt
@@ -20,8 +20,9 @@ package kwasm.format
  */
 data class ParseException(
     private val errorMsg: String,
-    val parseContext: ParseContext? = null
-) : Exception("(${parseContext ?: "Unknown Context"}) $errorMsg")
+    val parseContext: ParseContext? = null,
+    val origin: Throwable? = null
+) : Exception("(${parseContext ?: "Unknown Context"}) $errorMsg", origin)
 
 /** Throws a [ParseException] if the [condition] is not met. */
 inline fun parseCheck(

--- a/library/src/main/java/kwasm/format/text/Literal.kt
+++ b/library/src/main/java/kwasm/format/text/Literal.kt
@@ -36,7 +36,7 @@ fun <T : Any> List<Token>.parseLiteral(
         UInt::class -> {
             var literalToken = node as? IntegerLiteral.Signed
                 ?: node as? IntegerLiteral.Unsigned
-                ?: throw ParseException("Expected i32", context)
+                ?: throw ParseException("Expected i32 (unexpected token|unknown operator)", context)
             literalToken = literalToken.toUnsigned()
             literalToken.magnitude = 32
 
@@ -45,7 +45,7 @@ fun <T : Any> List<Token>.parseLiteral(
         Int::class -> {
             var literalToken = node as? IntegerLiteral.Signed
                 ?: node as? IntegerLiteral.Unsigned
-                ?: throw ParseException("Expected i32", context)
+                ?: throw ParseException("Expected i32 (unexpected token|unknown operator)", context)
             literalToken = literalToken.toSigned()
             literalToken.magnitude = 32
 
@@ -54,7 +54,7 @@ fun <T : Any> List<Token>.parseLiteral(
         ULong::class -> {
             var literalToken = node as? IntegerLiteral.Signed
                 ?: node as? IntegerLiteral.Unsigned
-                ?: throw ParseException("Expected i64", context)
+                ?: throw ParseException("Expected i64 (unexpected token|unknown operator)", context)
             literalToken = literalToken.toUnsigned()
 
             kwasm.ast.IntegerLiteral.U64(literalToken.value)
@@ -62,7 +62,7 @@ fun <T : Any> List<Token>.parseLiteral(
         Long::class -> {
             var literalToken = node as? IntegerLiteral.Signed
                 ?: node as? IntegerLiteral.Unsigned
-                ?: throw ParseException("Expected i64", context)
+                ?: throw ParseException("Expected i64 (unexpected token|unknown operator)", context)
             literalToken = literalToken.toSigned()
             literalToken.magnitude = 64
 
@@ -71,10 +71,10 @@ fun <T : Any> List<Token>.parseLiteral(
         Float::class -> {
             val literalToken = node as? FloatLiteral
                 ?: (node as? IntegerLiteral.Signed)
-                    ?.let { FloatLiteral("${it.value}", context = it.context) }
+                    ?.let { FloatLiteral("${it.sequence}", context = it.context) }
                 ?: (node as? IntegerLiteral.Unsigned)
-                    ?.let { FloatLiteral("${it.value}", context = it.context) }
-                ?: throw ParseException("Expected f32", context)
+                    ?.let { FloatLiteral("${it.sequence}", context = it.context) }
+                ?: throw ParseException("Expected f32 (unexpected token|unknown operator)", context)
             literalToken.magnitude = 32
 
             kwasm.ast.FloatLiteral.SinglePrecision(literalToken.value.toFloat())
@@ -82,17 +82,17 @@ fun <T : Any> List<Token>.parseLiteral(
         Double::class -> {
             val literalToken = node as? FloatLiteral
                 ?: (node as? IntegerLiteral.Signed)
-                    ?.let { FloatLiteral("${it.value}", context = it.context) }
+                    ?.let { FloatLiteral("${it.sequence}", context = it.context) }
                 ?: (node as? IntegerLiteral.Unsigned)
-                    ?.let { FloatLiteral("${it.value}", context = it.context) }
-                ?: throw ParseException("Expected f64", context)
+                    ?.let { FloatLiteral("${it.sequence}", context = it.context) }
+                ?: throw ParseException("Expected f64 (unexpected token|unknown operator)", context)
             literalToken.magnitude = 64
 
             kwasm.ast.FloatLiteral.DoublePrecision(literalToken.value)
         }
         String::class -> {
             val literalToken = node as? StringLiteral
-                ?: throw ParseException("Expected String", context)
+                ?: throw ParseException("Expected String (unexpected token)", context)
 
             kwasm.ast.StringLiteral(literalToken.value)
         }

--- a/library/src/main/java/kwasm/format/text/token/FloatLiteral.kt
+++ b/library/src/main/java/kwasm/format/text/token/FloatLiteral.kt
@@ -16,7 +16,6 @@ package kwasm.format.text.token
 
 import kwasm.format.ParseContext
 import kwasm.format.ParseException
-import kwasm.format.shiftColumnBy
 import kwasm.format.text.token.util.CanonincalNaN
 import kwasm.format.text.token.util.Frac
 import kwasm.format.text.token.util.Num
@@ -130,7 +129,7 @@ class FloatLiteral(
                 determineDecimalFloatValue(sequence, context)
             }
         } catch (e: NumberFormatException) {
-            throw ParseException("Invalid f${magnitude} format (unknown operator)", context, e)
+            throw ParseException("Invalid f$magnitude format (unknown operator)", context, e)
         }
     }
 

--- a/library/src/main/java/kwasm/format/text/token/IntegerLiteral.kt
+++ b/library/src/main/java/kwasm/format/text/token/IntegerLiteral.kt
@@ -151,11 +151,11 @@ sealed class IntegerLiteral<Type>(
         override fun checkMagnitude(value: Long, magnitude: Int): Boolean {
             val (_, sign) = sequence.parseLongSign()
             if (magnitude == 32) {
-                return value.toUInt().toInt() in Int.MIN_VALUE..Int.MAX_VALUE
-                    && (
-                    (sign == 1L && value <= UInt.MAX_VALUE.toLong()) ||
-                    (sign == -1L && value >= Int.MIN_VALUE.toLong())
-                    )
+                return value.toUInt().toInt() in Int.MIN_VALUE..Int.MAX_VALUE &&
+                    (
+                        (sign == 1L && value <= UInt.MAX_VALUE.toLong()) ||
+                            (sign == -1L && value >= Int.MIN_VALUE.toLong())
+                        )
             }
             if (magnitude == 64) return value in Long.MIN_VALUE..Long.MAX_VALUE
             val doubleValue = value.toDouble()

--- a/library/src/main/java/kwasm/format/text/token/IntegerLiteral.kt
+++ b/library/src/main/java/kwasm/format/text/token/IntegerLiteral.kt
@@ -16,10 +16,10 @@ package kwasm.format.text.token
 
 import kwasm.format.ParseContext
 import kwasm.format.ParseException
-import kwasm.format.shiftColumnBy
 import kwasm.format.text.token.util.Num
 import kwasm.format.text.token.util.TokenMatchResult
 import kwasm.format.text.token.util.parseLongSign
+import java.lang.NumberFormatException
 import kotlin.math.pow
 
 /**
@@ -48,16 +48,24 @@ import kotlin.math.pow
  */
 @OptIn(ExperimentalUnsignedTypes::class)
 sealed class IntegerLiteral<Type>(
-    protected val sequence: CharSequence,
+    val sequence: CharSequence,
     magnitude: Int = 64,
     override val context: ParseContext? = null
 ) : Token {
     val value: Type by lazy {
-        val res = parseValue()
+        val res = try {
+            parseValue()
+        } catch (e: NumberFormatException) {
+            throw ParseException(
+                errorMsg = "Illegal value: $sequence (i$magnitude constant|constant out of range)",
+                parseContext = context,
+                origin = e
+            )
+        }
         if (!checkMagnitude(res, this.magnitude)) {
             throw ParseException(
                 "Illegal value: $res, for expected magnitude: " +
-                    "${this.magnitude}: i${this.magnitude} constant",
+                    "${this.magnitude}: i${this.magnitude} constant (constant out of range)",
                 context
             )
         }
@@ -80,25 +88,22 @@ sealed class IntegerLiteral<Type>(
         magnitude: Int = 64,
         context: ParseContext? = null
     ) : IntegerLiteral<ULong>(sequence, magnitude, context) {
-        override fun parseValue(): ULong {
-            val expectHex: Boolean
-            val num: Num
-            if (sequence.length > 2 && sequence[0] == '0' && sequence[1] == 'x') {
-                expectHex = true
-                num = Num(
-                    sequence.subSequence(2, sequence.length),
-                    context.shiftColumnBy(2)
-                )
-            } else {
-                expectHex = false
-                num = Num(sequence, context)
-            }
+        private val bounds = 0uL..(2.0.pow(magnitude) - 1).toULong()
 
-            if (!expectHex && num.foundHexChars) {
-                throw ParseException("Unexpected hex integer", context)
+        override fun parseValue(): ULong {
+            var strToUse = sequence.toString().replace("_", "").toLowerCase()
+            var radix = 10
+            if (strToUse.startsWith("0x")) {
+                strToUse = strToUse.substring(2)
+                radix = 16
             }
-            num.forceHex = expectHex
-            return num.value
+            val result = if (magnitude <= 32) {
+                Integer.parseUnsignedInt(strToUse, radix).toUInt().toULong()
+            } else {
+                java.lang.Long.parseUnsignedLong(strToUse, radix).toULong()
+            }
+            return result.takeIf { it in bounds }
+                ?: throw ParseException("Integer constant out of range", context)
         }
 
         override fun checkMagnitude(value: ULong, magnitude: Int): Boolean = when (magnitude) {
@@ -118,36 +123,40 @@ sealed class IntegerLiteral<Type>(
         context: ParseContext? = null
     ) : IntegerLiteral<Long>(sequence, magnitude, context) {
         override fun parseValue(): Long {
-            val (sequenceOffset, sign) = sequence.parseLongSign()
-            val expectHex: Boolean
-            val num: Num
-            if (
-                sequence.length > 2 + sequenceOffset &&
-                sequence[sequenceOffset] == '0' &&
-                sequence[sequenceOffset + 1] == 'x'
-            ) {
-                expectHex = true
-                num = Num(
-                    sequence.subSequence(sequenceOffset + 2, sequence.length),
-                    context.shiftColumnBy(2 + sequenceOffset)
-                )
+            var strToUse = sequence.toString().replace("_", "").toLowerCase()
+            var radix = 10
+            if (strToUse.startsWith("0x")) {
+                strToUse = strToUse.substring(2)
+                radix = 16
+            } else if (strToUse.startsWith("-0x")) {
+                strToUse = "-" + strToUse.substring(3)
+                radix = 16
+            } else if (strToUse.startsWith("+0x")) {
+                strToUse = strToUse.substring(3)
+                radix = 16
+            }
+            return if (magnitude <= 32) {
+                if (strToUse.startsWith("-")) {
+                    java.lang.Long.parseLong(strToUse, radix)
+                } else {
+                    Integer.parseUnsignedInt(strToUse, radix).toLong()
+                }
+            } else if (strToUse.startsWith("-")) {
+                java.lang.Long.parseLong(strToUse, radix)
             } else {
-                expectHex = false
-                num = Num(
-                    sequence.subSequence(sequenceOffset, sequence.length),
-                    context.shiftColumnBy(sequenceOffset)
-                )
+                java.lang.Long.parseUnsignedLong(strToUse, radix)
             }
-
-            if (!expectHex && num.foundHexChars) {
-                throw ParseException("Unexpected hex integer", context)
-            }
-            num.forceHex = expectHex
-            return sign * num.value.toLong()
         }
 
         override fun checkMagnitude(value: Long, magnitude: Int): Boolean {
-            if (magnitude == 32) return value.toUInt().toInt() in Int.MIN_VALUE..Int.MAX_VALUE
+            val (_, sign) = sequence.parseLongSign()
+            if (magnitude == 32) {
+                return value.toUInt().toInt() in Int.MIN_VALUE..Int.MAX_VALUE
+                    && (
+                    (sign == 1L && value <= UInt.MAX_VALUE.toLong()) ||
+                    (sign == -1L && value >= Int.MIN_VALUE.toLong())
+                    )
+            }
             if (magnitude == 64) return value in Long.MIN_VALUE..Long.MAX_VALUE
             val doubleValue = value.toDouble()
             val extent = 2.0.pow(magnitude - 1)

--- a/library/src/main/java/kwasm/format/text/token/util/Num.kt
+++ b/library/src/main/java/kwasm/format/text/token/util/Num.kt
@@ -35,7 +35,7 @@ import kwasm.format.ParseException
  * ```
  */
 @OptIn(ExperimentalUnsignedTypes::class)
-class Num(private val sequence: CharSequence, context: ParseContext? = null) {
+class Num(val sequence: CharSequence, context: ParseContext? = null) {
     var forceHex: Boolean = false
 
     val foundHexChars: Boolean by lazy { digits.any { it >= 10 } }
@@ -50,7 +50,11 @@ class Num(private val sequence: CharSequence, context: ParseContext? = null) {
                 powerVal *= multiplier
             }
             power++
-            acc + byteVal.toULong() * powerVal
+            val next = acc + byteVal.toULong() * powerVal
+            if (byteVal != 0.toByte() && next < acc) {
+                throw ParseException("Invalid constant (constant out of range)", context)
+            }
+            next
         }
     }
 

--- a/library/src/test/java/kwasm/format/text/token/FloatLiteralTest.kt
+++ b/library/src/test/java/kwasm/format/text/token/FloatLiteralTest.kt
@@ -27,6 +27,14 @@ import kotlin.math.pow
 @RunWith(JUnit4::class)
 class FloatLiteralTest {
     @Test
+    fun throws_when32Bit_andExponentValueIsTooLarge_hex() {
+        val literal = FloatLiteral("0x1p128", 32)
+        assertThrows(ParseException::class.java) {
+            literal.value
+        }
+    }
+
+    @Test
     fun parsesInf() {
         val actual = FloatLiteral("inf")
         assertThat(actual.isInfinite()).isTrue()
@@ -204,13 +212,6 @@ class FloatLiteralTest {
     @Test
     fun decimalThrows_whenDotIsFirstElement() {
         val actual = FloatLiteral(".5")
-        val exception = assertThrows(ParseException::class.java) { actual.value }
-        assertThat(exception).hasMessageThat().contains("Invalid placement for decimal")
-    }
-
-    @Test
-    fun hexThrows_whenDotIsFirstElement() {
-        val actual = FloatLiteral("0x.5")
         val exception = assertThrows(ParseException::class.java) { actual.value }
         assertThat(exception).hasMessageThat().contains("Invalid placement for decimal")
     }

--- a/library/src/test/java/kwasm/format/text/token/IntegerLiteralTest.kt
+++ b/library/src/test/java/kwasm/format/text/token/IntegerLiteralTest.kt
@@ -28,6 +28,22 @@ import kotlin.math.absoluteValue
 @RunWith(JUnit4::class)
 class IntegerLiteralTest {
     @Test
+    fun parseSigned_throwsWhenOutOfRange_i64Dec() {
+        assertThrows(ParseException::class.java) {
+            val literal = IntegerLiteral.Signed("18446744073709551616")
+            literal.value
+        }
+    }
+
+    @Test
+    fun parseSigned_throwsWhenOutOfRange_i64Hex() {
+        assertThrows(ParseException::class.java) {
+            val literal = IntegerLiteral.Signed("-0x8000000000000001")
+            literal.value
+        }
+    }
+
+    @Test
     fun parsesUnsigned_base10() {
         val expected = 1234567890.toULong()
         val actual = IntegerLiteral.Unsigned("1234567890")
@@ -37,8 +53,7 @@ class IntegerLiteralTest {
     @Test
     fun throwsOnUnsigned_whenBase10_containsHexChars() {
         val literal = IntegerLiteral.Unsigned("1234aa")
-        val exception = assertThrows(ParseException::class.java) { literal.value }
-        assertThat(exception).hasMessageThat().contains("Unexpected hex integer")
+        assertThrows(ParseException::class.java) { literal.value }
     }
 
     @Test
@@ -52,7 +67,7 @@ class IntegerLiteralTest {
     fun throwsOnUnsigned_outsideMagnitude() {
         val literal = IntegerLiteral.Unsigned("256", 8)
         val exception = assertThrows(ParseException::class.java) { literal.value }
-        assertThat(exception).hasMessageThat().contains("Illegal value")
+        assertThat(exception).hasMessageThat().contains("Integer constant out of range")
     }
 
     @Test
@@ -88,8 +103,7 @@ class IntegerLiteralTest {
     @Test
     fun throwsOnSigned_whenBase10_containsHexChars() {
         val literal = IntegerLiteral.Signed("-1234aa")
-        val exception = assertThrows(ParseException::class.java) { literal.value }
-        assertThat(exception).hasMessageThat().contains("Unexpected hex integer")
+        assertThrows(ParseException::class.java) { literal.value }
     }
 
     @Test

--- a/library/src/test/java/kwasm/spectests/CoreSpecTest.kt
+++ b/library/src/test/java/kwasm/spectests/CoreSpecTest.kt
@@ -33,6 +33,8 @@ class CoreSpecTest {
             "align.wast",
             "binary.wast",
             "binary-leb128.wast",
+            "comments.wast",
+            "const.wast",
             "traps.wast"
         ],
     )

--- a/library/src/test/java/kwasm/spectests/command/ScriptModule.kt
+++ b/library/src/test/java/kwasm/spectests/command/ScriptModule.kt
@@ -88,7 +88,11 @@ sealed class ScriptModule : Command<Unit> {
 }
 
 fun List<Token>.parseScriptModule(fromIndex: Int): ParseResult<ScriptModule>? {
-    val normalModule = try { parseModule(fromIndex) } catch (e: ParseException) { null }
+    var parseException: ParseException? = null
+    val normalModule = try { parseModule(fromIndex) } catch (e: ParseException) {
+        parseException = e
+        null
+    }
     if (normalModule != null) {
         return ParseResult(ScriptModule.Normal(normalModule.astNode), normalModule.parseLength)
     }
@@ -121,7 +125,10 @@ fun List<Token>.parseScriptModule(fromIndex: Int): ParseResult<ScriptModule>? {
         val (bytes, length) = parseDataString(currentIndex)
         currentIndex += length
         ScriptModule.Binary(identifier?.astNode, this[indexOfStart].context!!, bytes)
-    } else throw ParseException("Unsupported module declaration", this[currentIndex].context)
+    } else {
+        throw parseException
+            ?: ParseException("Unsupported module declaration", this[currentIndex].context)
+    }
     if (!isClosedParen(currentIndex)) {
         throw ParseException("Expected closing paren", this[currentIndex].context)
     }


### PR DESCRIPTION
Also: greatly simplifies constant parsing by taking advantage of the JVM's built-in parsing.

Related Issue(s): #148 
