### PR TITLE
Enable a bunch of additional spec tests.

### DIFF
--- a/library/src/main/java/kwasm/format/binary/module/CustomSection.kt
+++ b/library/src/main/java/kwasm/format/binary/module/CustomSection.kt
@@ -38,6 +38,9 @@ fun BinaryParser.readCustomSection(totalSize: Int): CustomSection {
     val name = readName()
     val nameLen = position - beforePos
     val expectedBytesSize = totalSize - nameLen
+    if (expectedBytesSize < 0) {
+        throwException("Custom section has invalid size, can't contain name (unexpected end)")
+    }
     return CustomSection(name, readBytes(expectedBytesSize))
 }
 

--- a/library/src/main/java/kwasm/format/binary/module/Section.kt
+++ b/library/src/main/java/kwasm/format/binary/module/Section.kt
@@ -77,7 +77,9 @@ fun BinaryParser.readSection(): Section? {
         return section
     } catch (e: ParseException) {
         if ("Expected byte" in e.message ?: "") {
-            throwException(e.message + ": unexpected end of section or function")
+            throwException(
+                e.message + " (unexpected end of section or function|length out of bounds)"
+            )
         }
         throw e
     }

--- a/library/src/main/java/kwasm/format/text/module/Memory.kt
+++ b/library/src/main/java/kwasm/format/text/module/Memory.kt
@@ -92,8 +92,8 @@ internal fun List<Token>.parseMemoryBasic(
     currentIndex++
     val (id, updatedCounts) = parseOrCreateIdentifier<Identifier.Memory>(currentIndex, counts)
     currentIndex += id.parseLength
-    val memoryType = try { parseMemoryType(currentIndex) } catch (e: ParseException) { null }
-        ?: return null
+    if (isOpenParen(currentIndex)) return null
+    val memoryType = parseMemoryType(currentIndex)
     currentIndex += memoryType.parseLength
     parseCheck(contextAt(currentIndex), isClosedParen(currentIndex), "Expected ')'")
     currentIndex++

--- a/library/src/main/java/kwasm/format/text/module/Offset.kt
+++ b/library/src/main/java/kwasm/format/text/module/Offset.kt
@@ -53,8 +53,8 @@ fun List<Token>.parseOffset(
     val expression = parseExpression(currentIndex)
     parseCheck(
         contextAt(currentIndex),
-        expression.astNode.instructions.size == 1,
-        "Expected 1 instruction for abbreviated offset expression"
+        expression.astNode.instructions.isNotEmpty(),
+        "Expected offset expression"
     )
     currentIndex += expression.parseLength
 

--- a/library/src/main/java/kwasm/format/text/type/Limits.kt
+++ b/library/src/main/java/kwasm/format/text/type/Limits.kt
@@ -15,9 +15,9 @@
 package kwasm.format.text.type
 
 import kwasm.ast.type.Limits
-import kwasm.format.ParseException
 import kwasm.format.text.ParseResult
 import kwasm.format.text.parseLiteral
+import kwasm.format.text.token.IntegerLiteral
 import kwasm.format.text.token.Token
 
 /**
@@ -33,9 +33,9 @@ fun List<Token>.parseLimits(startingIndex: Int): ParseResult<Limits> {
     var currentIndex = startingIndex
     val min = parseLiteral(currentIndex, UInt::class)
     currentIndex += min.parseLength
-    val max = try {
+    val max = if (currentIndex < size && this[currentIndex] is IntegerLiteral<*>) {
         parseLiteral(currentIndex, UInt::class)
-    } catch (e: ParseException) {
+    } else {
         null
     }
     currentIndex += max?.parseLength ?: 0

--- a/library/src/main/java/kwasm/runtime/FunctionInstance.kt
+++ b/library/src/main/java/kwasm/runtime/FunctionInstance.kt
@@ -96,13 +96,15 @@ sealed class FunctionInstance(open val type: FunctionType) {
         val moduleInstance: ModuleInstance,
         val code: WasmFunction
     ) : FunctionInstance(
-        code.typeUse?.functionType ?: FunctionType(emptyList(), emptyList())
+        code.typeUse?.index?.let { moduleInstance.types[it] }
+            ?: code.typeUse?.functionType
+            ?: FunctionType(emptyList(), emptyList())
     ) {
         val flattenedInstructions by lazy { code.instructions.flatten(0) }
 
         @Suppress("UNCHECKED_CAST")
         override fun execute(context: ExecutionContext): ExecutionContext {
-            val type = code.typeUse?.functionType ?: FunctionType(emptyList(), emptyList())
+            val type = type
 
             if (type.returnValueEnums.size > 1)
                 throw KWasmRuntimeException("Function cannot have more than one return value.")

--- a/library/src/main/java/kwasm/runtime/instruction/ControlInstruction.kt
+++ b/library/src/main/java/kwasm/runtime/instruction/ControlInstruction.kt
@@ -286,8 +286,11 @@ internal fun ControlInstruction.CallIndirect.execute(context: ExecutionContext):
     val argument = context.stacks.operands.pop() as? IntValue
         ?: throw KWasmRuntimeException("Expected an i32 on the top of the stack")
 
-    if (argument.value >= table.elements.size)
-        throw KWasmRuntimeException("Table for module has no element at position ${argument.value}")
+    if (table.elements[argument.value] == null) {
+        throw KWasmRuntimeException(
+            "Table for module has no element at position ${argument.value} (uninitialized element)"
+        )
+    }
     val functionAddress = table.elements[argument.value]
         ?: throw KWasmRuntimeException(
             "No function found in the table with location ${argument.value}"

--- a/library/src/main/java/kwasm/runtime/memory/ByteBufferMemory.kt
+++ b/library/src/main/java/kwasm/runtime/memory/ByteBufferMemory.kt
@@ -36,9 +36,6 @@ internal class ByteBufferMemory(
     private val tempBuffer = ByteBuffer.allocate(8).order(ByteOrder.LITTLE_ENDIAN)
 
     init {
-        require(maximumPages > 0) {
-            "Maximum size must be > 0 pages"
-        }
         require(maximumPages >= initialPages) {
             "Maximum size specified as $maximumPages page(s), but initialPages = $initialPages"
         }

--- a/library/src/main/java/kwasm/validation/instruction/ExpressionValidator.kt
+++ b/library/src/main/java/kwasm/validation/instruction/ExpressionValidator.kt
@@ -67,7 +67,8 @@ class ExpressionValidator(
             !isConstant || node.instructions.all { it.isConstant(context) },
             parseContext = null,
             message = "Constant expressions may only contain ((i|f)(32|64)).const and " +
-                "global.get instructions operating on non-mutable global values"
+                "global.get instructions operating on non-mutable global values. " +
+                "(constant expression required)"
         )
 
         return node.instructions.validate(

--- a/library/src/main/java/kwasm/validation/instruction/InstructionSequenceValidator.kt
+++ b/library/src/main/java/kwasm/validation/instruction/InstructionSequenceValidator.kt
@@ -20,6 +20,7 @@ import kwasm.ast.instruction.Instruction
 import kwasm.ast.type.ValueType
 import kwasm.validation.ValidationContext
 import kwasm.validation.ValidationVisitor
+import kwasm.validation.instruction.control.validateReturn
 import kwasm.validation.validate
 
 /**
@@ -76,12 +77,14 @@ class InstructionSequenceValidator(
     ): ValidationContext.FunctionBody {
         val resultContext = node.fold(context) { ctx, inst ->
             if (inst == ControlInstruction.Unreachable) return ctx
+            if (inst == ControlInstruction.Return) return validateReturn(ctx)
             inst.validate(ctx)
         }
         requiredEndStack?.let {
             val topElements = resultContext.stack.takeLast(it.size)
             validate(topElements == it, parseContext = null) {
-                "Required end stack is: $it, but instruction sequence results in: $topElements"
+                "Required end stack is: $it, but instruction sequence results in: $topElements " +
+                    "(type mismatch)"
             }
             validate(!strictEndStackMatchRequired || topElements.size == resultContext.stack.size) {
                 "Strictly required end stack is: $it, but instruction sequence results in: " +

--- a/library/src/main/java/kwasm/validation/instruction/memory/Utils.kt
+++ b/library/src/main/java/kwasm/validation/instruction/memory/Utils.kt
@@ -25,6 +25,6 @@ internal fun ValidationContext.validateMemoryExists() {
     validateNotNull(
         memories[Index.ByInt(0)],
         parseContext = null,
-        message = "A memory must be included in the module"
+        message = "A memory must be included in the module (unknown memory)"
     )
 }

--- a/library/src/main/java/kwasm/validation/module/DataSegmentValidator.kt
+++ b/library/src/main/java/kwasm/validation/module/DataSegmentValidator.kt
@@ -43,7 +43,8 @@ object DataSegmentValidator : ModuleValidationVisitor<DataSegment> {
         context: ValidationContext.Module
     ): ValidationContext.Module {
         validateNotNull(context.memories[node.memoryIndex], parseContext = null) {
-            "No memory found with index ${node.memoryIndex} in module"
+            "No memory found with index ${node.memoryIndex} in module " +
+                "(unknown memory ${node.memoryIndex})"
         }
 
         node.offset.expression

--- a/library/src/main/java/kwasm/validation/module/ElementSegmentValidator.kt
+++ b/library/src/main/java/kwasm/validation/module/ElementSegmentValidator.kt
@@ -48,7 +48,7 @@ object ElementSegmentValidator : ModuleValidationVisitor<ElementSegment> {
         context: ValidationContext.Module
     ): ValidationContext.Module {
         val table = validateNotNull(context.tables[node.tableIndex], parseContext = null) {
-            "Table with index ${node.tableIndex} not found in the module"
+            "Table with index ${node.tableIndex} not found in the module (unknown table)"
         }
 
         validate(table.elemType == ElementType.FunctionReference, parseContext = null) {

--- a/library/src/main/java/kwasm/validation/module/ExportValidator.kt
+++ b/library/src/main/java/kwasm/validation/module/ExportValidator.kt
@@ -81,28 +81,28 @@ object ExportDescriptorValidator : ModuleValidationVisitor<ExportDescriptor<*>> 
                     context.functions[node.index],
                     parseContext = null
                 ) {
-                    "Function with index ${node.index} not found in the module"
+                    "Function with index ${node.index} not found in the module (unknown function)"
                 }
             is ExportDescriptor.Table ->
                 validateNotNull(
                     context.tables[node.index],
                     parseContext = null
                 ) {
-                    "Table with index ${node.index} not found in the module"
+                    "Table with index ${node.index} not found in the module (unknown table)"
                 }
             is ExportDescriptor.Memory ->
                 validateNotNull(
                     context.memories[node.index],
                     parseContext = null
                 ) {
-                    "Memory with index ${node.index} not found in the module"
+                    "Memory with index ${node.index} not found in the module (unknown memory)"
                 }
             is ExportDescriptor.Global ->
                 validateNotNull(
                     context.globals[node.index],
                     parseContext = null
                 ) {
-                    "Global with index ${node.index} not found in the module"
+                    "Global with index ${node.index} not found in the module (unknown global)"
                 }
         }
         return context

--- a/library/src/main/java/kwasm/validation/type/LimitsValidator.kt
+++ b/library/src/main/java/kwasm/validation/type/LimitsValidator.kt
@@ -43,15 +43,18 @@ fun Limits.validate(range: Long, context: ValidationContext) =
 class LimitsValidator(private val range: Long) : ValidationVisitor<Limits, ValidationContext> {
     override fun visit(node: Limits, context: ValidationContext): ValidationContext {
         validate(node.min <= range, parseContext = null) {
-            "Limits' min value of ${node.min} must not be greater than $range"
+            "Limits' min value of ${node.min} must not be greater than $range (memory size " +
+                "must be at most 65536 pages (4GiB))"
         }
         node.max?.let {
             validate(it <= range, parseContext = null) {
-                "Limits' max value of $it must not be greater than $range"
+                "Limits' max value of $it must not be greater than $range (memory size must " +
+                    "be at most 65536 pages (4GiB))"
             }
             validate(it >= node.min, parseContext = null) {
                 "Limits' max value must be greater-than or equal to its " +
-                    "min (min= ${node.min}, max= ${node.max})"
+                    "min (min= ${node.min}, max= ${node.max}|size minimum must not be greater " +
+                    "than maximum)"
             }
         }
         return context

--- a/library/src/test/java/kwasm/format/text/module/MemoryTest.kt
+++ b/library/src/test/java/kwasm/format/text/module/MemoryTest.kt
@@ -58,10 +58,10 @@ class MemoryTest {
     }
 
     @Test
-    fun parseMemoryBasic_returnsNull_ifMemoryTypeCouldntBeFound() {
-        val result = tokenizer.tokenize("(memory $0)", context)
-            .parseMemoryBasic(0, counts)
-        assertThat(result).isNull()
+    fun parseMemoryBasic_throws_ifMemoryTypeCouldntBeFound() {
+        assertThrows(ParseException::class.java) {
+            tokenizer.tokenize("(memory $0)", context).parseMemoryBasic(0, counts)
+        }
     }
 
     @Test

--- a/library/src/test/java/kwasm/format/text/module/OffsetTest.kt
+++ b/library/src/test/java/kwasm/format/text/module/OffsetTest.kt
@@ -37,16 +37,7 @@ class OffsetTest {
             tokenizer.tokenize("notAnInstruction", context).parseOffset(0)
         }
         assertThat(e).hasMessageThat()
-            .contains("Expected 1 instruction for abbreviated offset expression")
-    }
-
-    @Test
-    fun throws_ifAbbreviated_containsMoreThanOneExpression() {
-        val e = assertThrows(ParseException::class.java) {
-            tokenizer.tokenize("i32.const 1 i32.const 2", context).parseOffset(0)
-        }
-        assertThat(e).hasMessageThat()
-            .contains("Expected 1 instruction for abbreviated offset expression")
+            .contains("Expected offset expression")
     }
 
     @Test

--- a/library/src/test/java/kwasm/format/text/type/LimitsTest.kt
+++ b/library/src/test/java/kwasm/format/text/type/LimitsTest.kt
@@ -115,11 +115,11 @@ class LimitsTest {
     }
 
     @Test
-    fun parseTwoValuesWithMaxALotLargerThanMaxVal_returnsLimitsWithOnlyMin() {
+    fun parseTwoValuesWithMaxALotLargerThanMaxVal_throws() {
         val tokens = tokenizer.tokenize("1234567 100000000000", context)
-        val limits = tokens.parseLimits(0)
-        assertThat(limits.astNode.min).isEqualTo(1234567)
-        assertThat(limits.astNode.max).isEqualTo(null)
+        assertThrows(ParseException::class.java) {
+            tokens.parseLimits(0)
+        }
     }
 
     @Test

--- a/library/src/test/java/kwasm/spectests/command/Register.kt
+++ b/library/src/test/java/kwasm/spectests/command/Register.kt
@@ -37,7 +37,15 @@ data class Register(
     val moduleId: Identifier.Label?
 ) : Command<Unit> {
     override fun execute(context: ScriptContext) {
-        TODO("Not yet implemented")
+        val moduleToRegister = if (moduleId != null) {
+            context.programBuilder.modulesInOrder.removeLast()
+            requireNotNull(context.modules[moduleId])
+        } else {
+            context.programBuilder.modulesInOrder.removeLast().second
+        }
+        context.programBuilder.parsedModules.remove(moduleToRegister.identifier?.stringRepr ?: "")
+        context.programBuilder.withModule(importableName, moduleToRegister)
+        context.build()
     }
 }
 

--- a/library/src/test/java/kwasm/spectests/command/ScriptModule.kt
+++ b/library/src/test/java/kwasm/spectests/command/ScriptModule.kt
@@ -44,7 +44,7 @@ sealed class ScriptModule : Command<Unit> {
 
         override fun execute(context: ScriptContext) {
             context.modules[identifier] = module
-            context.programBuilder.withModule("", module)
+            context.programBuilder.withModule(identifier?.stringRepr ?: "", module)
             context.build()
         }
     }

--- a/library/src/test/java/kwasm/spectests/command/assertion/AssertUnlinkable.kt
+++ b/library/src/test/java/kwasm/spectests/command/assertion/AssertUnlinkable.kt
@@ -15,7 +15,6 @@
 package kwasm.spectests.command.assertion
 
 import com.google.common.truth.Truth.assertThat
-import kwasm.KWasmProgram
 import kwasm.ast.AstNode
 import kwasm.format.ParseException
 import kwasm.format.text.ParseResult
@@ -36,7 +35,7 @@ class AssertUnlinkable(
     val messageContains: String
 ) : AstNode, Command<Unit> {
     override fun execute(context: ScriptContext) {
-        val e = assertThrows(KWasmProgram.ImportMismatchException::class.java) {
+        val e = assertThrows(Exception::class.java) {
             action.execute(context)
         }
         assertThat(e).hasMessageThat().contains(messageContains)
@@ -48,7 +47,7 @@ fun List<Token>.parseAssertUnlinkable(fromIndex: Int): ParseResult<AssertUnlinka
     var currentIndex = fromIndex
     if (!isOpenParen(currentIndex)) return null
     currentIndex++
-    if (!isKeyword(currentIndex, "assert_malformed")) return null
+    if (!isKeyword(currentIndex, "assert_unlinkable")) return null
     currentIndex++
 
     val scriptModule = parseScriptModule(currentIndex)


### PR DESCRIPTION
The following spec tests were enabled:

* custom.wast
* data.wast
* elem.wast
* endianness.wast
* exports.wast
* forward.wast
* int_exprs.wast
* int_literals.wast
* memory.wast

Also:

* Ensures that KWasmProgramBuilder.build() is repeatable without side-effects.
* Adds the ability to specify Host Tables (still not ideal so far.. need to make this API better), Host Globals (do we need mutables?), and Host Memories.
* Fixes bugs required to make the above spec tests work.

Related Issue(s): #148 
